### PR TITLE
remove external service dependency when running async tests

### DIFF
--- a/networks/_modules/docker/variables.tf
+++ b/networks/_modules/docker/variables.tf
@@ -88,7 +88,7 @@ variable "network_id" {}
 
 variable "ethstats_secret" {}
 
-variable "ethstats_ip" {}
+variable  "ethstats_ip" {}
 
 variable "password_file_name" {}
 

--- a/networks/_modules/docker/waithook.tf
+++ b/networks/_modules/docker/waithook.tf
@@ -1,0 +1,23 @@
+# container that does the work of waithook.com which is very unstable causing our tests to fail
+resource "docker_container" "waithook" {
+  depends_on = [docker_container.ethstats]
+  image = "erolagnab/waithook:latest"
+  name  = format("%s-waithook", var.network_name)
+  hostname = "waithook.local"
+  restart = "no"
+  networks_advanced {
+    name         = docker_network.quorum.name
+    aliases      = ["waithook.local"]
+  }
+  ports {
+    internal = 3012
+    external = 3012
+  }
+  healthcheck {
+    test         = ["CMD", "nc", "-vz", "localhost", "3012"]
+    interval     = "3s"
+    retries      = 10
+    timeout      = "3s"
+    start_period = "3s"
+  }
+}


### PR DESCRIPTION
Previously we depend on waithook.com to verify the callback when calling
`sendTransactionAsync` API. However the service is not stable and
currently down causing tests failing.

This is to use the same codebase used in waithook.com and run in a
container to provide same mechanism used in the test