### PR TITLE
Improve pe network upgrade test stability

### DIFF
--- a/src/specs/02_advanced/qe81_network_upgrade.spec
+++ b/src/specs/02_advanced/qe81_network_upgrade.spec
@@ -114,7 +114,7 @@
  Node4 for should now stop appending new blocks (due to BAD BLOCK error)
 * Grep "quorum" in "Node4" for "Privacy enhanced transaction received while privacy enhancements are disabled. Please check your node configuration."
 * Stop "quorum" in "Node4" if consensus is istanbul
-* Check that "quorum" in "Node4" is "down"
+* Wait for "quorum" state in "Node4" to be "down"
 
 * Record the current block number, named it as "catchUpBlockNumber"
 

--- a/src/test/java/com/quorum/gauge/PENetworkUpgrade.java
+++ b/src/test/java/com/quorum/gauge/PENetworkUpgrade.java
@@ -163,6 +163,23 @@ public class PENetworkUpgrade extends AbstractSpecImplementation {
         assertThat(containerState).isEqualTo(state);
     }
 
+    @Step("Wait for <component> state in <node> to be <state>")
+    public void waitForNodeState(String component, String node, String state) {
+        String containerId = getComponentContainerId(component, node);
+        String containerState = infraService.wait(containerId).blockingFirst() ? "up" : "down";
+        int count = 20;
+        while (!containerState.equals(state) && count > 0){
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            count--;
+            containerState = infraService.wait(containerId).blockingFirst() ? "up" : "down";
+        }
+        assertThat(containerState).isEqualTo(state);
+    }
+
     @Step("Stop and start <node> using quorum version <qVersionKey> and tessera version <tVersionKey>")
     public void stopAndStartNodes(String node, String qVersionKey, String tVersionKey) {
         NetworkResources existingNetworkResources = mustHaveValue(DataStoreFactory.getScenarioDataStore(), "networkResources", NetworkResources.class);

--- a/src/test/java/com/quorum/gauge/PENetworkUpgrade.java
+++ b/src/test/java/com/quorum/gauge/PENetworkUpgrade.java
@@ -148,7 +148,7 @@ public class PENetworkUpgrade extends AbstractSpecImplementation {
             try {
                 Thread.sleep(1000L);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                throw new RuntimeException("Sleep interrupted during waitForTesseraToDiscoverKeysInNode", e);
             }
             count--;
         } while (count > 0);
@@ -172,7 +172,7 @@ public class PENetworkUpgrade extends AbstractSpecImplementation {
             try {
                 Thread.sleep(3000);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                throw new RuntimeException("Sleep interrupted during waitForNodeState", e);
             }
             count--;
             containerState = infraService.wait(containerId).blockingFirst() ? "up" : "down";
@@ -233,7 +233,7 @@ public class PENetworkUpgrade extends AbstractSpecImplementation {
                 retry--;
                 Thread.sleep(5000);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                throw new RuntimeException("Sleep interrupted during changeRaftLeader", e);
             }
             newLeader = raftService.getLeaderWithLocalEnodeInfo(QuorumNode.Node1).name();
         } while (newLeader == oldLeader && retry >= 0);


### PR DESCRIPTION
While running the network upgrade scenario using raft the quorum process panics when it gets into a BadBlock state (caused by receiving a privacy enhanced transaction while privacy enhancements are disabled).
The tests then check that the state of the quorum container is down.

When running on AWS it seems there is some delay between the quorum process dying and the state of the docker container being reported as down. The test was updated to wait for the container to reach the state rather than just check current container state. 