### PR TITLE
fix Github Actions workflows deprecation warnings

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   push:
     name: 'Build and Push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   condition:
     name: Evaluate workflow run conditions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       should_run: '${{ steps.check.outputs.val }}'
       use_aws: '${{ steps.check.outputs.useAws }}'
@@ -49,7 +49,7 @@ jobs:
     if: needs.condition.outputs.should_run == 'true'
     needs:
       - condition
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       output_dir: '${{ steps.prepare.outputs.output_dir }}'
       output_file: '${{ steps.prepare.outputs.output_file }}'
@@ -119,7 +119,7 @@ jobs:
             privacy-enhancements: 'true'
           - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
             privacy-enhancements: 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Download docker image'
         uses: actions/cache@v2
@@ -139,8 +139,8 @@ jobs:
             infraProfile="${{ secrets.AWS_REGION }}"
             mvnArg="-Dinfra.target=$infraFolder::$infraProfile"
             dockerEnv="-e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} -e TF_VAR_vpc_id=${{ secrets.AWS_VPC_ID }} -e TF_VAR_public_subnet_id=${{ secrets.AWS_PUBLIC_SUBNET_ID }}"
-            echo "::set-env name=INFRA_FOLDER::$infraFolder"
-            echo "::set-env name=INFRA_PROFILE::$infraProfile"
+            echo "INFRA_FOLDER=$infraFolder" >> $GITHUB_ENV
+            echo "INFRA_PROFILE=$infraProfile" >> $GITHUB_ENV
           fi
           echo "::set-output name=tag::$tagKey"
           echo "::set-output name=mvnArg::$mvnArg"
@@ -209,7 +209,7 @@ jobs:
       - condition
       - docker-build
       - run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Setup metadata'
         id: setup


### PR DESCRIPTION
- retire add-path and set-env commands being used in Github Actions workflows
- use ubuntu-18.04 consistently for builds