### PR TITLE
Switch default node type in configuration

### DIFF
--- a/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 @Component
 @ConfigurationProperties(prefix = "quorum")
 public class QuorumNetworkProperty {
-    private Map<QuorumNode, Node> nodes = new HashMap<>();
+    private Map<String, Node> nodes = new HashMap<>();
     private Map<String, WalletData> wallets = new HashMap<>();
     private String consensus;
     private SocksProxy socksProxy;
@@ -48,15 +48,19 @@ public class QuorumNetworkProperty {
         this.socksProxy = socksProxy;
     }
 
-    public Map<QuorumNode, Node> getNodes() {
+    public Map<String, Node> getNodes() {
         return nodes;
     }
 
-    public void setNodes(Map<QuorumNode, Node> nodes) {
-        for (Map.Entry<QuorumNode, Node> entry : nodes.entrySet()) {
-            entry.getValue().setName(entry.getKey().name());
+    public void setNodes(Map<String, Node> nodes) {
+        for (Map.Entry<String, Node> entry : nodes.entrySet()) {
+            entry.getValue().setName(entry.getKey());
         }
         this.nodes = nodes;
+    }
+
+    public QuorumNode getQuorumNode(QuorumNetworkProperty.Node node) {
+        return QuorumNode.valueOf(node.getName());
     }
 
     public Map<String, WalletData> getWallets() {
@@ -67,16 +71,8 @@ public class QuorumNetworkProperty {
         this.wallets = wallets;
     }
 
-    public Map<String, Node> getNodesAsString() {
-        Map<String, Node> converted = new HashMap<>();
-        for (Map.Entry<QuorumNode, Node> quorumNodeNodeEntry : nodes.entrySet()) {
-            converted.put(quorumNodeNodeEntry.getKey().name(), quorumNodeNodeEntry.getValue());
-        }
-        return converted;
-    }
-
     public Node getNode(String nodeName) {
-        Node node = Optional.ofNullable(nodes.get(QuorumNode.valueOf(nodeName))).orElseThrow(() -> new RuntimeException("no such node with name: " + nodeName));
+        Node node = Optional.ofNullable(nodes.get(nodeName)).orElseThrow(() -> new RuntimeException("no such node with name: " + nodeName));
         node.setName(nodeName);
         return node;
     }

--- a/src/main/java/com/quorum/gauge/common/QuorumNodeListParameterParser.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNodeListParameterParser.java
@@ -44,7 +44,7 @@ public class QuorumNodeListParameterParser extends CustomParameterParser<List<No
         return Arrays.stream(nodes.split(","))
                 .map(String::trim)
                 .map(nodeName -> {
-                    final Node node = props.getNodesAsString().get(nodeName);
+                    final Node node = props.getNodes().get(nodeName);
                     if(node == null) {
                         throw new IllegalArgumentException("Node " + nodeName + " not found in network properties");
                     }

--- a/src/main/java/com/quorum/gauge/common/QuorumNodeParameterParser.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNodeParameterParser.java
@@ -34,7 +34,7 @@ public class QuorumNodeParameterParser extends CustomParameterParser<Node> {
         final QuorumNetworkProperty props
             = (QuorumNetworkProperty) DataStoreFactory.getSuiteDataStore().get("networkProperties");
 
-        final Node node = props.getNodesAsString().get(nodeName);
+        final Node node = props.getNodes().get(nodeName);
         if (node == null) {
             throw new IllegalArgumentException("Node " + nodeName + " not found in network properties");
         }

--- a/src/main/java/com/quorum/gauge/services/AccountService.java
+++ b/src/main/java/com/quorum/gauge/services/AccountService.java
@@ -97,22 +97,6 @@ public class AccountService extends AbstractService {
         throw new IllegalArgumentException("no such alias in the network property: " + alias);
     }
 
-    /**
-     *
-     * @param alias
-     * @return account address in the network property
-     */
-    public QuorumNetworkProperty.Node nodeByAlias(String alias) {
-        for (QuorumNode n : networkProperty().getNodes().keySet()) {
-            QuorumNetworkProperty.Node node = networkProperty().getNodes().get(n);
-            node.setName(n.name());
-            if (node.getAccountAliases().containsKey(alias)) {
-                return node;
-            }
-        }
-        throw new IllegalArgumentException("no such alias in the network property: " + alias);
-    }
-
     public Observable<String> getAccountAddress(QuorumNetworkProperty.Node source, String ethAccount) {
         if (ethAccount == null) {
             return getDefaultAccountAddress(source);

--- a/src/main/java/com/quorum/gauge/services/GraphQLService.java
+++ b/src/main/java/com/quorum/gauge/services/GraphQLService.java
@@ -58,7 +58,7 @@ public class GraphQLService extends AbstractService {
     }
 
     private String graphqlUrl(QuorumNode node) {
-        QuorumNetworkProperty.Node nodeConfig = networkProperty().getNodes().get(node);
+        QuorumNetworkProperty.Node nodeConfig = networkProperty().getNodes().get(node.name());
         if (nodeConfig == null) {
             throw new IllegalArgumentException("Node " + node + " not found in config");
         }

--- a/src/main/java/com/quorum/gauge/services/PrivacyService.java
+++ b/src/main/java/com/quorum/gauge/services/PrivacyService.java
@@ -74,17 +74,6 @@ public class PrivacyService extends AbstractService {
         return matches.get(0);
     }
 
-    public QuorumNetworkProperty.Node nodeById(String alias) {
-        for (QuorumNode n : networkProperty().getNodes().keySet()) {
-            QuorumNetworkProperty.Node node = networkProperty().getNodes().get(n);
-            node.setName(n.name());
-            if (node.getPrivacyAddressAliases().containsKey(alias)) {
-                return node;
-            }
-        }
-        throw new IllegalArgumentException("no node has privacy address: " + alias);
-    }
-
     public String id(QuorumNode node, String name) {
         return getQuorumNodeConfig(node).getPrivacyAddressAliases().get(name);
     }
@@ -94,7 +83,7 @@ public class PrivacyService extends AbstractService {
     }
 
     private QuorumNetworkProperty.Node getQuorumNodeConfig(QuorumNode node) {
-        QuorumNetworkProperty.Node nodeConfig = networkProperty().getNodes().get(node);
+        QuorumNetworkProperty.Node nodeConfig = networkProperty().getNodes().get(node.name());
         if (nodeConfig == null) {
             throw new IllegalArgumentException("Node " + node + " not found in config");
         }

--- a/src/main/java/com/quorum/gauge/services/QuorumNodeConnectionFactory.java
+++ b/src/main/java/com/quorum/gauge/services/QuorumNodeConnectionFactory.java
@@ -54,7 +54,7 @@ public class QuorumNodeConnectionFactory {
     }
 
     public Web3jService getWeb3jService(QuorumNode node) {
-        QuorumNetworkProperty.Node nodeConfig = networkProperty.getNodes().get(node);
+        QuorumNetworkProperty.Node nodeConfig = networkProperty.getNodes().get(node.name());
         if (nodeConfig == null) {
             throw new IllegalArgumentException("Can't find node " + node + " in the configuration");
         }

--- a/src/main/java/com/quorum/gauge/services/RaftService.java
+++ b/src/main/java/com/quorum/gauge/services/RaftService.java
@@ -98,12 +98,12 @@ public class RaftService extends AbstractService {
         String leaderEnode = response.getResult();
         logger.debug("Retrieved leader enode: {}", leaderEnode);
 
-        Map<QuorumNode, Node> nodes = connectionFactory().getNetworkProperty().getNodes();
-        for (QuorumNode nodeId : nodes.keySet()) {
+        Map<String, Node> nodes = connectionFactory().getNetworkProperty().getNodes();
+        for (Node n : nodes.values()) {
             Request<?, NodeInfo> nodeInfoRequest = new Request<>(
                     "admin_nodeInfo",
                     null,
-                    connectionFactory().getWeb3jService(nodeId),
+                    connectionFactory().getWeb3jService(n),
                     NodeInfo.class
             );
 
@@ -111,7 +111,7 @@ public class RaftService extends AbstractService {
             String thisEnode = nodeInfo.getEnode();
             logger.debug("Retrieved enode info: {}", thisEnode);
             if (thisEnode.contains(leaderEnode)) {
-                return nodeId;
+                return connectionFactory().getNetworkProperty().getQuorumNode(n);
             }
         }
 
@@ -132,12 +132,12 @@ public class RaftService extends AbstractService {
         String leaderEnode = response.getResult();
         logger.debug("Retrieved leader enode: {}", leaderEnode);
 
-        Map<QuorumNode, Node> nodes = connectionFactory().getNetworkProperty().getNodes();
-        for (Map.Entry<QuorumNode,Node> nodeEntry : nodes.entrySet()) {
+        Map<String, Node> nodes = connectionFactory().getNetworkProperty().getNodes();
+        for (Map.Entry<String, Node> nodeEntry : nodes.entrySet()) {
             String thisEnode = nodeEntry.getValue().getEnodeUrl();
             logger.debug("Retrieved enode info: {}", thisEnode);
             if (thisEnode.contains(leaderEnode)) {
-                return nodeEntry.getKey();
+                return connectionFactory().getNetworkProperty().getQuorumNode(nodeEntry.getValue());
             }
         }
 

--- a/src/test/java/com/quorum/gauge/MultiTenancy.java
+++ b/src/test/java/com/quorum/gauge/MultiTenancy.java
@@ -3,6 +3,7 @@ package com.quorum.gauge;
 import com.google.common.primitives.Ints;
 import com.quorum.gauge.common.Context;
 import com.quorum.gauge.common.PrivacyFlag;
+import com.quorum.gauge.common.QuorumNetworkProperty;
 import com.quorum.gauge.common.QuorumNetworkProperty.Node;
 import com.quorum.gauge.common.QuorumNode;
 import com.quorum.gauge.common.config.WalletData;
@@ -61,8 +62,7 @@ public class MultiTenancy extends AbstractSpecImplementation {
             .map(StringUtils::trim)
             .map(rawScope -> {
                 String expandedScope = rawScope;
-                for (QuorumNode qn : networkProperty.getNodes().keySet()) {
-                    Node n = networkProperty.getNode(qn.name());
+                for (QuorumNetworkProperty.Node n : networkProperty.getNodes().values()) {
                     for (String alias : n.getPrivacyAddressAliases().keySet()) {
                         if (rawScope.contains("=" + alias)) {
                             nodeList.add(n.getName());

--- a/src/test/java/com/quorum/gauge/PluginSecurity.java
+++ b/src/test/java/com/quorum/gauge/PluginSecurity.java
@@ -62,7 +62,7 @@ public class PluginSecurity extends AbstractSpecImplementation {
         boolean expectAuthorized = "success".equalsIgnoreCase(policy);
         String token = mustHaveValue(DataStoreFactory.getScenarioDataStore(), clientId, String.class);
         Context.storeAccessToken(token);
-        Map<String, QuorumNetworkProperty.Node> nodeMap = networkProperty.getNodesAsString();
+        Map<String, QuorumNetworkProperty.Node> nodeMap = networkProperty.getNodes();
         table.getTableRows().stream()
                 .map(r -> new ApiCall(r.getCell("callApi"), r.getCell("targetNode")))
                 .onClose(Context::removeAccessToken)


### PR DESCRIPTION
As the `QuorumNode` enum type is deprecated to allow custom node names, this switches the default type that configuration uses to name the nodes.
Places that still need the QuorumNode can use the helper method to convert.