### PR TITLE
[Improvement] Wait for geth to be down in Partial Network upgrade AT

### DIFF
--- a/src/specs/02_advanced/qe81_network_upgrade.spec
+++ b/src/specs/02_advanced/qe81_network_upgrade.spec
@@ -83,9 +83,11 @@
 * Stop "quorum" in "Node1"
 * Run gethInit in "Node1" with genesis file having privacyEnhancementsBlock set to "peBlockNumber" + "-1"
  Geth init fails
+* Wait for "quorum" state in "Node1" to be "down"
 * Grep "quorum" in "Node1" for "mismatching Privacy Enhancements fork block in database"
 * Check that "quorum" in "Node1" is "down"
 * Run gethInit in "Node1" with genesis file having privacyEnhancementsBlock set to "peBlockNumber" + "1"
+* Wait for "quorum" state in "Node1" to be "down"
  Geth init succeeds but displays the warning message that quorum won't start unless the privacy manager supports privacy enhancements
 * Grep "quorum" in "Node1" for "Please ensure your privacy manager is upgraded and supports privacy enhancements"
  Tessera hasn't been updated so quorum should fail to start


### PR DESCRIPTION
### Summary

Noticed that sometimes it was failing to find the right `Cannot start quorum with privacy enhancements enabled while the transaction manager does not support it` text in the logs. Seems that adding a wait to the node to be down, will then make sure the logs are updated to `grep` be used.

### Changes

* Add `* Wait for "quorum" state in "Node1" to be "down"` in two cases that were missing to find the data in logs