### PR TITLE
[Fix] Use the right network block number to activate privacy enhancements

### DIFF
--- a/src/main/java/com/quorum/gauge/services/TransactionService.java
+++ b/src/main/java/com/quorum/gauge/services/TransactionService.java
@@ -90,7 +90,7 @@ public class TransactionService extends AbstractService {
     }
 
     public Optional<TransactionReceipt> pollTransactionReceipt(QuorumNetworkProperty.Node node, String transactionHash) {
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 60; i++) {
             EthGetTransactionReceipt r = getTransactionReceipt(node, transactionHash)
                 .delay(3, TimeUnit.SECONDS)
                 .blockingFirst();

--- a/src/specs/02_advanced/qe81_network_upgrade.spec
+++ b/src/specs/02_advanced/qe81_network_upgrade.spec
@@ -79,7 +79,6 @@
  PartyProtection transactions are rejected in quorum Node1 as privacy enhancemetns are not enabled yet
 * Deploying a "PartyProtection" simple smart contract with initial value "42" in "Node1"'s default account and it's private for "Node4" fails with message "PrivacyEnhancements are disabled"
  Run geth init with privacyEnhancementsBlock=currentBlockHeight-1
-//* Record the current block number, named it as "peBlockNumber" // TODO ricardolyn: check where peBlockNumber is used
 * Record the current block number in "Node1", named it as "peBlockNumberBeforeStop"
 * Stop "quorum" in "Node1"
 * Wait for "quorum" state in "Node1" to be "down"

--- a/src/specs/02_advanced/qe81_network_upgrade.spec
+++ b/src/specs/02_advanced/qe81_network_upgrade.spec
@@ -79,9 +79,12 @@
  PartyProtection transactions are rejected in quorum Node1 as privacy enhancemetns are not enabled yet
 * Deploying a "PartyProtection" simple smart contract with initial value "42" in "Node1"'s default account and it's private for "Node4" fails with message "PrivacyEnhancements are disabled"
  Run geth init with privacyEnhancementsBlock=currentBlockHeight-1
-* Record the current block number, named it as "peBlockNumber"
+//* Record the current block number, named it as "peBlockNumber" // TODO ricardolyn: check where peBlockNumber is used
+* Record the current block number in "Node1", named it as "peBlockNumberBeforeStop"
 * Stop "quorum" in "Node1"
-* Run gethInit in "Node1" with genesis file having privacyEnhancementsBlock set to "peBlockNumber" + "-1"
+* Wait for "quorum" state in "Node1" to be "down"
+* Record the current block number in "Node2", named it as "peBlockNumber"
+* Run gethInit in "Node1" with genesis file having privacyEnhancementsBlock set to "peBlockNumberBeforeStop" + "-1"
  Geth init fails
 * Grep "quorum" in "Node1" for "mismatching Privacy Enhancements fork block in database"
 * Check that "quorum" in "Node1" is "down"
@@ -208,6 +211,7 @@
 * Record the current block number, named it as "catchUpBlockNumber"
 
 * Stop and start "Node2" using quorum version <q_to_version> and tessera version <t_to_version>
+* Wait for "quorum" state in "Node2" to be "up"
  Node2 is now privacy enhancements capable but privacy enhancements are not enabled (geth init hasnt been run with a genesis file containing privacyEnhancementsBlock)
  Node1 is not able to connect to Node2 (as they have different values for PrivacyEnhancementsBlock)
 * Enable privacy enhancements in tessera "Node2"

--- a/src/test/java/com/quorum/gauge/BlockSynchronization.java
+++ b/src/test/java/com/quorum/gauge/BlockSynchronization.java
@@ -265,7 +265,12 @@ public class BlockSynchronization extends AbstractSpecImplementation {
 
     @Step("Record the current block number, named it as <name>")
     public void recordCurrentBlockNumber(String name) {
-        BigInteger currentBlockNumber = utilService.getCurrentBlockNumber().blockingFirst().getBlockNumber();
+        recordCurrentBlockNumber(QuorumNode.Node1, name);
+    }
+
+    @Step("Record the current block number in <node>, named it as <name>")
+    public void recordCurrentBlockNumber(QuorumNode node, String name) {
+        BigInteger currentBlockNumber = utilService.getCurrentBlockNumberFrom(node).blockingFirst().getBlockNumber();
         logger.debug("Current block number = {}", currentBlockNumber);
         DataStoreFactory.getScenarioDataStore().put(name, currentBlockNumber);
     }


### PR DESCRIPTION
### Summary

As while we get the block number before stoping a Node, the node might jump to the next one while is shutting down, which leads to us having an older one. if we use this to then activate the privacy enhancements (a block above), we might still have an old block number to activate the features for.

This fix by using the block number from another node to be sure that we use a future one to activate the privacy enhancements. Thanks @nicolae-leonte-go for the help.

### Changes

* Do a second get of the block number after stopping Node1 in the test `Partial Network upgrade from an old version (q2.5.0/t0.10.5) to privacy enhancements enabled version of geth and tessera`
* Increase the number of times we get the receipt, as locally on MacOS 30 times seems not enough (@nicolae-leonte-go please confirm if might be something else).

