### PR TITLE
upgrade Terraform and Quorum Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ env/travis-*/
 **/.DS_Store
 
 **/.terraform
+**/.terraform.lock.hcl
 **/terraform.d
 **/terraform.tfstate*
 **/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
 FROM alpine:latest
 
-ARG TERRAFORM_VERSION=0.12.26
+ARG TERRAFORM_VERSION=0.14.7
 ARG SOLC_VERSION=0.5.5
 ARG GAUGE_VERSION=1.0.8
 # To have a consistent run, this must be the same as gauge-java.version in pom.xml
 ARG GAUGE_JAVA_VERSION=0.7.7
-ARG TERRAFORM_PROVIDER_QUORUM_VERSION=1.0.0-beta.1
 ARG MAVEN_VERSION=3.6.3
 ARG JDK_VERSION=11.0.7
 LABEL maintainer="info@goquorum.com" \
     TERRAFORM_VERSION="${TERRAFORM_VERSION}" \
     SOLC_VERSION=""${SOLC_VERSION} \
     GAUGE_VERSION="${GAUGE_VERSION}" \
-    TERRAFORM_PROVIDER_QUORUM_VERSION="${TERRAFORM_PROVIDER_QUORUM_VERSION}" \
     MAVEN_VERSION="${MAVEN_VERSION}" \
     JDK_VERSION="openjdk-${JDK_VERSION}"
 WORKDIR /workspace
@@ -32,9 +30,6 @@ RUN apk -q --no-cache --update add tar bash \
         (wget -O /tmp/downloads/gauge.zip -q https://github.com/getgauge/gauge/releases/download/v${GAUGE_VERSION}/gauge-${GAUGE_VERSION}-linux.x86_64.zip \
         && unzip -q -o /tmp/downloads/gauge.zip -d bin && gauge install java --version ${GAUGE_JAVA_VERSION} > /dev/null && gauge install > /dev/null) & \
         p="$!"; pids="$pids $p"; echo "  >> Installing Gauge ${GAUGE_VERSION} - PID $p"; \
-        (wget -O /tmp/downloads/provider.zip -q https://dl.bintray.com/quorumengineering/terraform/terraform-provider-quorum/v${TERRAFORM_PROVIDER_QUORUM_VERSION}/terraform-provider-quorum_${TERRAFORM_PROVIDER_QUORUM_VERSION}_linux_amd64.zip \
-        && unzip -q -o /tmp/downloads/provider.zip -d bin) & \
-        p="$!"; pids="$pids $p"; echo "  >> Installing Terraform Quorum Provider ${TERRAFORM_PROVIDER_QUORUM_VERSION} - PID $p"; \
         (wget -O /tmp/downloads/maven.tar.gz -q https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
         && tar -xzf /tmp/downloads/maven.tar.gz -C /usr/local/maven --strip-components=1) & \
         p="$!"; pids="$pids $p"; echo "  >> Installing Maven ${MAVEN_VERSION} - PID $p"; \

--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ Development environment requires the following:
 
 With built-in provisioning feature:
 - [Docker Engine](https://docs.docker.com/engine/) or [Docker Desktop](https://www.docker.com/products/docker-desktop)
-- [Terraform](https://terraform.io) 0.12.x
-- [Terraform Provider Quorum](https://bintray.com/quorumengineering/terraform/terraform-provider-quorum)
-   - The provider should be downloaded from the link and unzipped into the directory `~/.terraform.d/plugins/`
-   - Refer to [this guide](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) for more information regarding provider installation
+- [Terraform](https://terraform.io) 0.13+
   
 **For more details on tools and versions being used, please refer to [Dockerfile](Dockerfile)**
 

--- a/networks/_modules/docker/outputs.tf
+++ b/networks/_modules/docker/outputs.tf
@@ -2,6 +2,10 @@ output "docker_network_name" {
   value = docker_network.quorum.name
 }
 
+output "docker_network_ipam_config" {
+  value = docker_network.quorum.ipam_config
+}
+
 output "container_geth_datadir" {
   value = local.container_geth_datadir
 }

--- a/networks/_modules/docker/versions.tf
+++ b/networks/_modules/docker/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "2.11.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/networks/_modules/ignite/main.tf
+++ b/networks/_modules/ignite/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    quorum = {
+      source = "ConsenSys/quorum"
+      version = "0.2.0"
+    }
+  }
+}
+
 locals {
   network_name              = coalesce(var.network_name, random_string.network-name.result)
   generated_dir             = var.output_dir
@@ -49,7 +58,7 @@ quorum:
 %{for i in data.null_data_source.meta[*].inputs.idx~}
     ${format("Node%d:", i + 1)}
 %{ if var.concensus == "istanbul" ~}
-      istanbul-validator-id: ${quorum_bootstrap_node_key.nodekeys-generator[i].istanbul_address}
+      istanbul-validator-id: "${quorum_bootstrap_node_key.nodekeys-generator[i].istanbul_address}"
 %{ endif ~}
       enode-url: ${local.enode_urls[i]}
       account-aliases:
@@ -58,7 +67,7 @@ quorum:
 %{endfor~}
       privacy-address-aliases:
 %{for k in local.tm_named_keys_alloc[i]~}
-        ${k}: ${element(quorum_transaction_manager_keypair.tm.*.public_key_b64, index(local.tm_named_keys_all, k))}
+        ${k}: "${element(quorum_transaction_manager_keypair.tm.*.public_key_b64, index(local.tm_named_keys_all, k))}"
 %{endfor~}
       url: ${data.null_data_source.meta[i].inputs.nodeUrl}
       third-party-url: ${data.null_data_source.meta[i].inputs.tmThirdpartyUrl}

--- a/networks/plugins/hashicorp-vault.tf
+++ b/networks/plugins/hashicorp-vault.tf
@@ -37,7 +37,7 @@ resource "docker_container" "vault_server" {
     name     = local.vault_server_container_name
     hostname = local.vault_server_container_name
     networks_advanced {
-      name = data.docker_network.quorum.name
+      name = module.docker.docker_network_name
       ipv4_address = cidrhost(lookup(local.network_config, "subnet"), 201)
       aliases = [local.cert_san_workaround_hostname]
     }

--- a/networks/plugins/plugin-security.tf
+++ b/networks/plugins/plugin-security.tf
@@ -4,7 +4,7 @@ locals {
   oauth2_server_admin_port = { internal = 4445, external = 4445 } # for admin
   include_security         = lookup(var.plugins, "security", null) != null
 
-  network_config = element(tolist(data.docker_network.quorum.ipam_config), 0)
+  network_config = element(tolist(module.docker.docker_network_ipam_config), 0)
 
   application_yml = yamldecode(file(module.network.application_yml_file))
 }
@@ -27,17 +27,13 @@ quorum:
 YML
 }
 
-data "docker_network" "quorum" {
-  name = module.docker.docker_network_name
-}
-
 resource "docker_container" "hydra" {
   count    = local.include_security ? 1 : 0
   image    = "oryd/hydra:v1.3.2-alpine"
   name     = local.oauth2_server
   hostname = local.oauth2_server
   networks_advanced {
-    name         = data.docker_network.quorum.name
+    name         = module.docker.docker_network_name
     ipv4_address = cidrhost(lookup(local.network_config, "subnet"), 200)
   }
   env = [

--- a/networks/plugins/versions.tf
+++ b/networks/plugins/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "2.11.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/networks/template/versions.tf
+++ b/networks/template/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "2.11.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/networks/typical/versions.tf
+++ b/networks/typical/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "2.11.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/src/specs/01_basic/fill_transaction.spec
+++ b/src/specs/01_basic/fill_transaction.spec
@@ -2,7 +2,7 @@
 
  Tags: basic
 
-##  test fill transaction
+## Test fill transaction
 
 * Deploy Simple Storage contract using fillTransaction api with an initial value of "129" called from "Node1" private for "Node2". Name this contract as "C1"
 


### PR DESCRIPTION
- Migrate to support terraform 0.14.7
- Source Terraform Provider Quorum from Terraform Registry instead of manual download