### PR TITLE
Remove repeated timeout/retry defaults and factor out common ops

### DIFF
--- a/src/main/java/com/quorum/gauge/ext/EnhancedClientTransactionManager.java
+++ b/src/main/java/com/quorum/gauge/ext/EnhancedClientTransactionManager.java
@@ -29,6 +29,9 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
 
+import static com.quorum.gauge.services.AbstractService.DEFAULT_MAX_RETRY;
+import static com.quorum.gauge.services.AbstractService.DEFAULT_SLEEP_DURATION_IN_MILLIS;
+
 /**
  * Support additional privacy constructs
  *
@@ -38,12 +41,17 @@ import java.util.List;
 public class EnhancedClientTransactionManager extends ClientTransactionManager {
 
     private List<PrivacyFlag> contractFlag;
+
     private Quorum quorum;
 
     public EnhancedClientTransactionManager(Quorum quorum, String fromAddress, String privateFrom, List<String> privateFor, List<PrivacyFlag> contractFlag, int attempts, int sleepDuration) {
         super(quorum, fromAddress, privateFrom, privateFor, attempts, sleepDuration);
         this.quorum = quorum;
         this.contractFlag = contractFlag;
+    }
+
+    public EnhancedClientTransactionManager(Quorum quorum, String fromAddress, String privateFrom, List<String> privateFor, List<PrivacyFlag> contractFlag) {
+        this(quorum, fromAddress, privateFrom, privateFor, contractFlag, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS);
     }
 
     @Override

--- a/src/main/java/com/quorum/gauge/services/AbstractService.java
+++ b/src/main/java/com/quorum/gauge/services/AbstractService.java
@@ -22,17 +22,25 @@ package com.quorum.gauge.services;
 import com.quorum.gauge.common.Context;
 import com.quorum.gauge.common.QuorumNetworkProperty;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.quorum.Quorum;
+import org.web3j.quorum.enclave.Enclave;
+import org.web3j.quorum.tx.ClientTransactionManager;
+import org.web3j.quorum.tx.QuorumTransactionManager;
+import org.web3j.tx.RawTransactionManager;
 import org.web3j.tx.gas.ContractGasProvider;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Optional;
 
 public abstract class AbstractService {
 
     public static final BigInteger DEFAULT_GAS_LIMIT = new BigInteger("47b760", 16);
     BigInteger DEFAULT_PERMISSIONS_GAS_LIMIT = new BigInteger("8C6180", 16);
-    int DEFAULT_SLEEP_DURATION_IN_MILLIS = 2000;
-    int DEFAULT_MAX_RETRY = 30;
+    public static int DEFAULT_SLEEP_DURATION_IN_MILLIS = 2000;
+    public static int DEFAULT_MAX_RETRY = 30;
 
     private ContractGasProvider permContractGasProvider = new PermissionContractGasProvider();
     private ContractGasProvider permContractDepGasProvider = new PermissionContractDeployGasProvider();
@@ -76,5 +84,25 @@ public abstract class AbstractService {
 
     public void setPermContractDepGasProvider(ContractGasProvider permContractDepGasProvider) {
         this.permContractDepGasProvider = permContractDepGasProvider;
+    }
+
+    public ClientTransactionManager clientTransactionManager(Web3j web3j, String fromAddress, String privateFrom, List<String> privateFor) {
+        return new ClientTransactionManager(web3j, fromAddress, privateFrom, privateFor, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS);
+    }
+
+    public org.web3j.tx.ClientTransactionManager vanillaClientTransactionManager(Web3j web3j, String fromAddress) {
+        return new org.web3j.tx.ClientTransactionManager(web3j, fromAddress, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS);
+    }
+
+    public RawTransactionManager rawTransactionManager(Web3j web3j, Credentials credentials) {
+        return new RawTransactionManager(web3j, credentials, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS);
+    }
+
+    public QuorumTransactionManager quorumTransactionManager(Quorum web3j,
+                                                              Credentials credentials,
+                                                              String privateFrom,
+                                                              List<String> privateFor,
+                                                              Enclave enclave) {
+        return new QuorumTransactionManager(web3j, credentials, privateFrom, privateFor, enclave, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS);
     }
 }

--- a/src/main/java/com/quorum/gauge/services/ContractCodeReaderService.java
+++ b/src/main/java/com/quorum/gauge/services/ContractCodeReaderService.java
@@ -72,9 +72,8 @@ public class ContractCodeReaderService extends AbstractService {
                 eoa,
                 privacyService.id(privateFromAlias),
                 privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                List.of(PrivacyFlag.StandardPrivate),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                List.of(PrivacyFlag.StandardPrivate)
+            );
             return ContractCodeReader.deploy(client, clientTransactionManager, getPermContractDepGasProvider()).flowable().toObservable();
         });
     }
@@ -88,8 +87,7 @@ public class ContractCodeReaderService extends AbstractService {
                 eoa,
                 privacyService.id(privateFromAlias),
                 privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                List.of(PrivacyFlag.StandardPrivate),
-                DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
+                List.of(PrivacyFlag.StandardPrivate)
             ))
             .flatMap(txManager -> ContractCodeReader.load(
                 contractAddress, client, txManager, BigInteger.ZERO, DEFAULT_GAS_LIMIT).setLastCodeSize(targetContractAddress)

--- a/src/main/java/com/quorum/gauge/services/ContractService.java
+++ b/src/main/java/com/quorum/gauge/services/ContractService.java
@@ -250,7 +250,7 @@ public class ContractService extends AbstractService {
                 address,
                 privacyService.id(privateFromAlias),
                 privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                Collections.emptyList()
+                Collections.EMPTY_LIST
             ))
             .flatMap(txManager -> SimpleStorage.load(
                 contractAddress, client, txManager, BigInteger.ZERO, DEFAULT_GAS_LIMIT).set(value).flowable().toObservable()
@@ -286,7 +286,7 @@ public class ContractService extends AbstractService {
                 address,
                 privacyService.id(privateFromAlias),
                 privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                Collections.emptyList()
+                Collections.EMPTY_LIST
             ))
             .flatMap(txManager -> SimpleStorageDelegate.load(
                 contractAddress, client, txManager, BigInteger.ZERO, DEFAULT_GAS_LIMIT).set(value).flowable().toObservable()

--- a/src/main/java/com/quorum/gauge/services/ContractService.java
+++ b/src/main/java/com/quorum/gauge/services/ContractService.java
@@ -109,9 +109,7 @@ public class ContractService extends AbstractService {
                 address,
                 privacyService.id(privateFromAliases),
                 privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                finalFlags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                finalFlags);
             return SimpleStorage.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -143,9 +141,7 @@ public class ContractService extends AbstractService {
                 address,
                 null,
                 privateFor,
-                flags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                flags);
             return SimpleStorage.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -236,9 +232,7 @@ public class ContractService extends AbstractService {
         final List<String> privateFor = target.stream().map(q -> privacyService.id(q)).collect(Collectors.toList());
 
         return accountService.getDefaultAccountAddress(source)
-            .map(address -> new EnhancedClientTransactionManager(
-                client, address, null, privateFor, flags, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
-            ))
+            .map(address -> new EnhancedClientTransactionManager(client, address, null, privateFor, flags))
             .flatMap(txManager -> SimpleStorage.load(
                 contractAddress, client, txManager, BigInteger.ZERO, gasLimit).set(value).flowable().toObservable()
             );
@@ -256,7 +250,7 @@ public class ContractService extends AbstractService {
                 address,
                 privacyService.id(privateFromAlias),
                 privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                Collections.EMPTY_LIST, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
+                Collections.emptyList()
             ))
             .flatMap(txManager -> SimpleStorage.load(
                 contractAddress, client, txManager, BigInteger.ZERO, DEFAULT_GAS_LIMIT).set(value).flowable().toObservable()
@@ -275,7 +269,7 @@ public class ContractService extends AbstractService {
                 address,
                 null,
                 null,
-                Collections.emptyList(), DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
+                Collections.emptyList()
             ))
             .flatMap(txManager -> SimpleStorage.load(
                 contractAddress, client, txManager, BigInteger.ZERO, DEFAULT_GAS_LIMIT).set(value).flowable().toObservable()
@@ -292,7 +286,7 @@ public class ContractService extends AbstractService {
                 address,
                 privacyService.id(privateFromAlias),
                 privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                Collections.EMPTY_LIST, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
+                Collections.emptyList()
             ))
             .flatMap(txManager -> SimpleStorageDelegate.load(
                 contractAddress, client, txManager, BigInteger.ZERO, DEFAULT_GAS_LIMIT).set(value).flowable().toObservable()
@@ -312,11 +306,7 @@ public class ContractService extends AbstractService {
         Web3j client = connectionFactory().getWeb3jConnection(node);
         return accountService.getDefaultAccountAddress(node)
             .flatMap(address -> {
-                org.web3j.tx.ClientTransactionManager txManager = new org.web3j.tx.ClientTransactionManager(
-                    client,
-                    address,
-                    DEFAULT_MAX_RETRY,
-                    DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                org.web3j.tx.ClientTransactionManager txManager = vanillaClientTransactionManager(client, address);
                 return ClientReceipt.deploy(
                     client,
                     txManager,
@@ -393,18 +383,14 @@ public class ContractService extends AbstractService {
                 fromAddress,
                 null,
                 Arrays.asList(privacyService.id(target)),
-                Arrays.asList(privacyType),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                Arrays.asList(privacyType));
         } else {
             txManager = new EnhancedClientTransactionManager(
                 client,
                 fromAddress,
                 null,
                 null,
-                List.of(PrivacyFlag.StandardPrivate),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                List.of(PrivacyFlag.StandardPrivate));
         }
         try {
             switch (contractName.toLowerCase().trim()) {
@@ -470,18 +456,14 @@ public class ContractService extends AbstractService {
                 fromAddress,
                 null,
                 Arrays.asList(privacyService.id(target)),
-                List.of(privacyType),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                List.of(privacyType));
         } else {
             transactionManager = new EnhancedClientTransactionManager(
                 client,
                 fromAddress,
                 null,
                 null,
-                List.of(PrivacyFlag.StandardPrivate),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                List.of(PrivacyFlag.StandardPrivate));
         }
         switch (contractName.toLowerCase().trim()) {
             case "storea":
@@ -511,13 +493,11 @@ public class ContractService extends AbstractService {
     public Observable<? extends Contract> createClientReceiptPrivateSmartContract(Node source, String ethAccount, String privateFromAlias, List<String> privateForAliases) {
         Quorum client = connectionFactory().getConnection(source);
         return accountService.getAccountAddress(source, ethAccount).flatMap(address -> {
-            ClientTransactionManager clientTransactionManager = new ClientTransactionManager(
+            ClientTransactionManager clientTransactionManager = clientTransactionManager(
                 client,
                 address,
                 privacyService.id(privateFromAlias),
-                privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                privacyService.ids(privateForAliases));
             return ClientReceipt.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -528,13 +508,11 @@ public class ContractService extends AbstractService {
     public Observable<? extends Contract> createClientReceiptPrivateSmartContract(QuorumNode source, QuorumNode target) {
         Quorum client = connectionFactory().getConnection(source);
         return accountService.getDefaultAccountAddress(source).flatMap(address -> {
-            ClientTransactionManager clientTransactionManager = new ClientTransactionManager(
+            ClientTransactionManager clientTransactionManager = clientTransactionManager(
                 client,
                 address,
                 null,
-                Arrays.asList(privacyService.id(target)),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                List.of(privacyService.id(target)));
             return ClientReceipt.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -546,11 +524,7 @@ public class ContractService extends AbstractService {
         Web3j client = connectionFactory().getWeb3jConnection(node);
         return accountService.getDefaultAccountAddress(node)
             .flatMap(address -> {
-                org.web3j.tx.ClientTransactionManager txManager = new org.web3j.tx.ClientTransactionManager(
-                    client,
-                    address,
-                    DEFAULT_MAX_RETRY,
-                    DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                org.web3j.tx.ClientTransactionManager txManager = vanillaClientTransactionManager(client, address);
                 return ClientReceipt.load(contractAddress, client, txManager, BigInteger.valueOf(0), DEFAULT_GAS_LIMIT)
                     .deposit(new byte[32], value).flowable().toObservable();
             });
@@ -559,13 +533,11 @@ public class ContractService extends AbstractService {
     public Observable<TransactionReceipt> updateClientReceiptPrivate(QuorumNode source, QuorumNode target, String contractAddress, BigInteger value) {
         Quorum client = connectionFactory().getConnection(source);
         return accountService.getDefaultAccountAddress(source).flatMap(address -> {
-            ClientTransactionManager txManager = new ClientTransactionManager(
+            ClientTransactionManager txManager = clientTransactionManager(
                 client,
                 address,
                 null,
-                Arrays.asList(privacyService.id(target)),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                List.of(privacyService.id(target)));
             return ClientReceipt.load(contractAddress, client, txManager,
                 BigInteger.valueOf(0),
                 DEFAULT_GAS_LIMIT).deposit(new byte[32], value).flowable().toObservable();
@@ -626,13 +598,11 @@ public class ContractService extends AbstractService {
         Quorum client = connectionFactory().getConnection(source);
         return accountService.getAccountAddress(source, ethAccount)
             .flatMap(address -> {
-                ClientTransactionManager clientTransactionManager = new ClientTransactionManager(
+                ClientTransactionManager clientTransactionManager = clientTransactionManager(
                     client,
                     address,
                     privacyService.id(privateFromAlias),
-                    privateForAliases.stream().map(privacyService::id).collect(Collectors.toList()),
-                    DEFAULT_MAX_RETRY,
-                    DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                    privacyService.ids(privateForAliases));
                 return SimpleStorageDelegate.deploy(client,
                     clientTransactionManager,
                     BigInteger.valueOf(0),

--- a/src/main/java/com/quorum/gauge/services/NestedContractService.java
+++ b/src/main/java/com/quorum/gauge/services/NestedContractService.java
@@ -65,9 +65,7 @@ public class NestedContractService extends AbstractService {
                 address,
                 null,
                 target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
-                flags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                flags);
             return C1.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -79,13 +77,11 @@ public class NestedContractService extends AbstractService {
     public Observable<? extends Contract> createPublicC1Contract(int initialValue, QuorumNode source) {
         Quorum client = connectionFactory().getConnection(source);
         return accountService.getDefaultAccountAddress(source).flatMap(address -> {
-            ClientTransactionManager clientTransactionManager = new ClientTransactionManager(
+            ClientTransactionManager clientTransactionManager = clientTransactionManager(
                 client,
                 address,
                 null,
-                null,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                null);
             return C1.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -106,9 +102,7 @@ public class NestedContractService extends AbstractService {
                 address,
                 null,
                 target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
-                flags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                flags);
             return C2.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -169,9 +163,7 @@ public class NestedContractService extends AbstractService {
                 address,
                 null,
                 target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
-                flags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                flags);
             return C2.load(contractAddress, client, txManager,
                 BigInteger.valueOf(0),
                 DEFAULT_GAS_LIMIT).restoreFromC1().flowable().toObservable();
@@ -181,13 +173,11 @@ public class NestedContractService extends AbstractService {
     public Observable<TransactionReceipt> updateC1Contract(QuorumNode source, List<QuorumNode> target, String contractAddress, int newValue) {
         Quorum client = connectionFactory().getConnection(source);
         return accountService.getDefaultAccountAddress(source).flatMap(address -> {
-            ClientTransactionManager txManager = new ClientTransactionManager(
+            ClientTransactionManager txManager = clientTransactionManager(
                 client,
                 address,
                 null,
-                target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()));
             return C1.load(contractAddress, client, txManager,
                 BigInteger.valueOf(0),
                 DEFAULT_GAS_LIMIT).set(BigInteger.valueOf(newValue)).flowable().toObservable();
@@ -202,9 +192,7 @@ public class NestedContractService extends AbstractService {
                 address,
                 null,
                 target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
-                flags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                flags);
             return C2.load(contractAddress, client, txManager,
                 BigInteger.valueOf(0),
                 DEFAULT_GAS_LIMIT).set(BigInteger.valueOf(newValue)).flowable().toObservable();
@@ -228,9 +216,7 @@ public class NestedContractService extends AbstractService {
                 address,
                 null,
                 target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
-                flags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                flags);
             return C1.load(contractAddress, client, txManager,
                 BigInteger.valueOf(0),
                 DEFAULT_GAS_LIMIT).newContractC2(newValue).flowable().toObservable();

--- a/src/main/java/com/quorum/gauge/services/PermissionsContractService.java
+++ b/src/main/java/com/quorum/gauge/services/PermissionsContractService.java
@@ -31,8 +31,6 @@ import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.tx.Contract;
 import org.web3j.tx.TransactionManager;
 
-import java.math.BigInteger;
-
 @Service
 public class PermissionsContractService extends AbstractService {
     private static final Logger logger = LoggerFactory.getLogger(PermissionsContractService.class);
@@ -42,11 +40,7 @@ public class PermissionsContractService extends AbstractService {
 
     private org.web3j.tx.ClientTransactionManager getTxManager(QuorumNetworkProperty.Node node, Web3j client){
         String fromAddress = accountService.getDefaultAccountAddress(node).blockingFirst();
-        return new org.web3j.tx.ClientTransactionManager(
-            client,
-            fromAddress,
-            DEFAULT_MAX_RETRY,
-            DEFAULT_SLEEP_DURATION_IN_MILLIS);
+        return vanillaClientTransactionManager(client, fromAddress);
     }
 
     public Observable<? extends Contract> createPermissionsGenericContracts(QuorumNetworkProperty.Node node, String contractName, String upgrContractAddress, String version) {

--- a/src/main/java/com/quorum/gauge/services/PrivacyService.java
+++ b/src/main/java/com/quorum/gauge/services/PrivacyService.java
@@ -26,6 +26,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class PrivacyService extends AbstractService {
@@ -72,6 +73,10 @@ public class PrivacyService extends AbstractService {
             throw new RuntimeException("there are " + matches.size() + " nodes having this privacy address alias: " + alias);
         }
         return matches.get(0);
+    }
+
+    public List<String> ids(final List<String> nodeAliases) {
+        return nodeAliases.stream().map(this::id).collect(Collectors.toList());
     }
 
     public String id(QuorumNode node, String name) {

--- a/src/main/java/com/quorum/gauge/services/RawContractService.java
+++ b/src/main/java/com/quorum/gauge/services/RawContractService.java
@@ -95,11 +95,7 @@ public class RawContractService extends AbstractService {
         try {
             Credentials credentials = WalletUtils.loadCredentials(wallet.getWalletPass(), wallet.getWalletPath());
 
-            RawTransactionManager qrtxm = new RawTransactionManager(
-                    web3j,
-                    credentials,
-                    DEFAULT_MAX_RETRY,
-                    DEFAULT_SLEEP_DURATION_IN_MILLIS);
+            RawTransactionManager qrtxm = rawTransactionManager(web3j, credentials);
 
             return SimpleStorage.deploy(web3j,
                     qrtxm,
@@ -122,11 +118,7 @@ public class RawContractService extends AbstractService {
         try {
             Credentials credentials = WalletUtils.loadCredentials(wallet.getWalletPass(), wallet.getWalletPath());
 
-            RawTransactionManager qrtxm = new RawTransactionManager(
-                    web3j,
-                    credentials,
-                    DEFAULT_MAX_RETRY,
-                    DEFAULT_SLEEP_DURATION_IN_MILLIS);
+            RawTransactionManager qrtxm = rawTransactionManager(web3j, credentials);
 
             return SimpleStorage.load(contractAddress, web3j,
                     qrtxm,
@@ -148,13 +140,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> SimpleStorage.deploy(client,
                 qrtxm,
                 BigInteger.valueOf(0),
@@ -169,13 +159,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> SimpleStorage.load(contractAddress, client,
                 qrtxm,
                 BigInteger.valueOf(0),
@@ -190,13 +178,11 @@ public class RawContractService extends AbstractService {
         try {
             Credentials credentials = WalletUtils.loadCredentials(wallet.getWalletPass(), wallet.getWalletPath());
 
-            QuorumTransactionManager qrtxm = new QuorumTransactionManager(client,
+            QuorumTransactionManager qrtxm = quorumTransactionManager(client,
                     credentials,
                     privacyService.id(source),
-                    Arrays.asList(privacyService.id(target)),
-                    enclave,
-                    DEFAULT_MAX_RETRY,
-                    DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                    List.of(privacyService.id(target)),
+                    enclave);
 
             return SimpleStorage.deploy(client,
                     qrtxm,
@@ -220,13 +206,11 @@ public class RawContractService extends AbstractService {
         try {
             Credentials credentials = WalletUtils.loadCredentials(wallet.getWalletPass(), wallet.getWalletPath());
 
-            QuorumTransactionManager qrtxm = new QuorumTransactionManager(client,
+            QuorumTransactionManager qrtxm = quorumTransactionManager(client,
                     credentials,
                     privacyService.id(source),
-                    Arrays.asList(privacyService.id(target)),
-                    enclave,
-                    DEFAULT_MAX_RETRY,
-                    DEFAULT_SLEEP_DURATION_IN_MILLIS);
+                    List.of(privacyService.id(target)),
+                    enclave);
 
             return SimpleStorage.load(contractAddress, client,
                     qrtxm,
@@ -406,13 +390,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> ClientReceipt.deploy(client,
                 qrtxm,
                 BigInteger.valueOf(0),
@@ -426,13 +408,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> ClientReceipt.load(contractAddress, client,
                 qrtxm,
                 BigInteger.valueOf(0),
@@ -447,13 +427,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> SimpleStorageDelegate.deploy(client,
                 qrtxm,
                 BigInteger.valueOf(0),
@@ -469,13 +447,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> SimpleStorageDelegate.load(contractAddress, client,
                 qrtxm,
                 BigInteger.valueOf(0),
@@ -491,13 +467,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> SneakyWrapper.deploy(client,
                 qrtxm,
                 BigInteger.valueOf(0),
@@ -512,13 +486,11 @@ public class RawContractService extends AbstractService {
 
         return Observable.fromCallable(() -> wallet)
             .flatMap(walletData -> Observable.fromCallable(() -> WalletUtils.loadCredentials(walletData.getWalletPass(), walletData.getWalletPath())))
-            .flatMap(cred -> Observable.just(new QuorumTransactionManager(client,
+            .flatMap(cred -> Observable.just(quorumTransactionManager(client,
                 cred,
                 privacyService.id(source, sourceNamedKey),
-                targetNamedKeys.stream().map(privacyService::id).collect(Collectors.toList()),
-                enclave,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS)))
+                privacyService.ids(targetNamedKeys),
+                enclave)))
             .flatMap(qrtxm -> SneakyWrapper.load(contractAddress, client,
                 qrtxm,
                 BigInteger.valueOf(0),

--- a/src/main/java/com/quorum/gauge/services/StorageMasterService.java
+++ b/src/main/java/com/quorum/gauge/services/StorageMasterService.java
@@ -60,14 +60,8 @@ public class StorageMasterService extends AbstractService {
         }
 
         return accountService.getDefaultAccountAddress(source).flatMap(address -> {
-            EnhancedClientTransactionManager clientTransactionManager = new EnhancedClientTransactionManager(
-                client,
-                address,
-                null,
-                privateFor,
-                flags,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+            EnhancedClientTransactionManager clientTransactionManager
+                = new EnhancedClientTransactionManager(client, address, null, privateFor, flags);
             return StorageMaster.deploy(client,
                 clientTransactionManager,
                 BigInteger.valueOf(0),
@@ -85,9 +79,8 @@ public class StorageMasterService extends AbstractService {
         final List<String> privateFor = target.stream().map(q -> privacyService.id(q)).collect(Collectors.toList());
 
         return accountService.getDefaultAccountAddress(source).flatMap(acctAddress -> {
-            EnhancedClientTransactionManager txManager = new EnhancedClientTransactionManager(
-                client, acctAddress, null, privateFor, flags, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
-            );
+            EnhancedClientTransactionManager txManager
+                = new EnhancedClientTransactionManager(client, acctAddress, null, privateFor, flags);
             return createSSFromSM(txManager, client, contractAddress, gasLimit, newValue);
         });
     }
@@ -129,9 +122,8 @@ public class StorageMasterService extends AbstractService {
         final List<String> privateFor = target.stream().map(q -> privacyService.id(q)).collect(Collectors.toList());
 
         return accountService.getDefaultAccountAddress(source).flatMap(acctAdress -> {
-            EnhancedClientTransactionManager txManager = new EnhancedClientTransactionManager(
-                client, acctAdress, null, privateFor, flags, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
-            );
+            EnhancedClientTransactionManager txManager
+                = new EnhancedClientTransactionManager(client, acctAdress, null, privateFor, flags);
             StorageMaster storageMaster = StorageMaster.load(contractAddress, client, txManager, BigInteger.ZERO, gasLimit);
             return storageMaster.createSimpleStorageC2C3(value).flowable().toObservable();
         });
@@ -148,9 +140,8 @@ public class StorageMasterService extends AbstractService {
         final List<String> privateFor = target.stream().map(q -> privacyService.id(q)).collect(Collectors.toList());
 
         return accountService.getDefaultAccountAddress(source).flatMap(acctAddress -> {
-            EnhancedClientTransactionManager txManager = new EnhancedClientTransactionManager(
-                client, acctAddress, null, privateFor, flags, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
-            );
+            EnhancedClientTransactionManager txManager
+                = new EnhancedClientTransactionManager(client, acctAddress, null, privateFor, flags);
             StorageMaster storageMaster = StorageMaster.load(
                 contractAddress, client, txManager, BigInteger.ZERO, gasLimit);
             return storageMaster.setC2C3Value(value).flowable().toObservable();
@@ -161,13 +152,9 @@ public class StorageMasterService extends AbstractService {
         Quorum client = connectionFactory().getConnection(source);
 
         return accountService.getDefaultAccountAddress(source).flatMap(address -> {
-            org.web3j.tx.ClientTransactionManager clientTransactionManager = new org.web3j.tx.ClientTransactionManager(
-                client,
-                address,
-                DEFAULT_MAX_RETRY,
-                DEFAULT_SLEEP_DURATION_IN_MILLIS);
+            org.web3j.tx.ClientTransactionManager txManager = vanillaClientTransactionManager(client, address);
             return StorageMaster.deploy(client,
-                clientTransactionManager,
+                txManager,
                 BigInteger.valueOf(0),
                 gas).flowable().toObservable();
         });
@@ -179,9 +166,7 @@ public class StorageMasterService extends AbstractService {
                                                                                      final int newValue) {
         final Quorum client = connectionFactory().getConnection(source);
         return accountService.getDefaultAccountAddress(source).flatMap(acctAddress -> {
-            org.web3j.tx.ClientTransactionManager txManager = new org.web3j.tx.ClientTransactionManager(
-                client, acctAddress, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
-            );
+            org.web3j.tx.ClientTransactionManager txManager = vanillaClientTransactionManager(client, acctAddress);
             return createSSFromSM(txManager, client, contractAddress, gasLimit, newValue);
         });
     }


### PR DESCRIPTION
Most of the types TransactionManagers created use the default settings for timeout and retry count, so added convenience methods for creating these to reduce the amount of noise they make in amongst the test code.

Also added a convenience method for converting node names to Tessera Keys, so reduce the amount of inline streams, which can clutter up the method calls.