### PR TITLE
[Upgrade] Update AT to match new changes in GoQuorum with Get v1.9.19

### DIFF
--- a/config/application-local.4nodes.yml
+++ b/config/application-local.4nodes.yml
@@ -5,19 +5,19 @@ quorum:
       privacy-address: BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=
       url: http://localhost:22000
       third-party-url: http://localhost:9081
-      graphql-url: http://localhost:8001/graphql
+      graphql-url: http://localhost:22000/graphql
     Node2:
       privacy-address: QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=
       url: http://localhost:22001
       third-party-url: http://localhost:9082
-      graphql-url: http://localhost:8002/graphql
+      graphql-url: http://localhost:22001/graphql
     Node3:
       privacy-address: 1iTZde/ndBHvzhcl7V68x44Vx7pl8nwx9LqnM/AfJUg=
       url: http://localhost:22002
       third-party-url: http://localhost:9083
-      graphql-url: http://localhost:8003/graphql
+      graphql-url: http://localhost:22002/graphql
     Node4:
       privacy-address: oNspPPgszVUFw0qmGFfWwh1uxVUXgvBxleXORHj07g8=
       url: http://localhost:22003
       third-party-url: http://localhost:9084
-      graphql-url: http://localhost:8004/graphql
+      graphql-url: http://localhost:22003/graphql

--- a/networks/_modules/docker-helper/main.tf
+++ b/networks/_modules/docker-helper/main.tf
@@ -11,10 +11,10 @@ locals {
       port = {
         http    = { internal = var.geth.container.port.http, external = var.geth.host.port.http_start + idx }
         ws      = var.geth.container.port.ws == -1 ? null : { internal = var.geth.container.port.ws, external = var.geth.host.port.ws_start + idx }
-        graphql = var.geth.container.port.graphql == -1 ? null : { internal = var.geth.container.port.graphql, external = var.geth.host.port.graphql_start + idx }
         p2p     = var.geth.container.port.p2p
         raft    = var.geth.container.port.raft
       }
+      graphql = var.geth.container.graphql
       ip = {
         private = cidrhost(local.container_network_cidr, idx + 1 + 10)
         public  = "localhost"

--- a/networks/_modules/docker-helper/variables.tf
+++ b/networks/_modules/docker-helper/variables.tf
@@ -10,19 +10,21 @@ variable "geth" {
   type = object({
     container = object({
       image = object({ name = string, local = bool })
-      port  = object({ raft = number, p2p = number, http = number, ws = number, graphql = number })
+      port  = object({ raft = number, p2p = number, http = number, ws = number })
+      graphql = bool
     })
     host = object({
-      port = object({ http_start = number, ws_start = number, graphql_start = number })
+      port = object({ http_start = number, ws_start = number})
     })
   })
   default = {
     container = {
       image = { name = "quorumengineering/quorum:latest", local = false }
-      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1, graphql = -1 }
+      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1 }
+      graphql = false
     }
     host = {
-      port = { http_start = 22000, ws_start = -1, graphql_start = -1 }
+      port = { http_start = 22000, ws_start = -1 }
     }
   }
   description = "geth Docker container configuration "

--- a/networks/_modules/docker/geth.tf
+++ b/networks/_modules/docker/geth.tf
@@ -69,14 +69,22 @@ resource "docker_container" "geth" {
     <<RUN
 #Quorum${count.index + 1}
 
+echo "Original files in datadir (ls ${local.container_geth_datadir})"
+ls ${local.container_geth_datadir}
+
 if [ "$ALWAYS_REFRESH" == "true" ]; then
   echo "Deleting ${local.container_geth_datadir} to refresh with original datadir"
   rm -rf ${local.container_geth_datadir}
 fi
-if [ ! -d "${local.container_geth_datadir}" ]; then
-  echo "Copying mounted datadir to ${local.container_geth_datadir}"
+
+if [ ! -f "${local.container_geth_datadir}/genesis.json" ]; then
+  echo "Genesis file missing. Copying mounted datadir to ${local.container_geth_datadir}"
+  rm -r ${local.container_geth_datadir}
   cp -r ${local.container_geth_datadir_mounted} ${local.container_geth_datadir}
 fi
+echo "Current files in datadir (ls ${local.container_geth_datadir})"
+ls ${local.container_geth_datadir}
+
 echo "ls ${local.container_plugin_acctdir}"
 ls ${local.container_plugin_acctdir}
 echo "Deleting any files in ${local.container_plugin_acctdir}"

--- a/networks/_modules/docker/geth.tf
+++ b/networks/_modules/docker/geth.tf
@@ -1,7 +1,8 @@
 locals {
-  publish_http_ports    = [for idx in local.node_indices : [var.geth_networking[idx].port.http]]
-  publish_ws_ports      = var.geth_networking[0].port.ws == null ? [for idx in local.node_indices : []] : [for idx in local.node_indices : [var.geth_networking[idx].port.ws]]
-  publish_graphql_ports = var.geth_networking[0].port.graphql == null ? [for idx in local.node_indices : []] : [for idx in local.node_indices : [var.geth_networking[idx].port.graphql]]
+  publish_http_ports = [for idx in local.node_indices : [
+    var.geth_networking[idx].port.http]]
+  publish_ws_ports = var.geth_networking[0].port.ws == null ? [for idx in local.node_indices : []] : [for idx in local.node_indices : [
+    var.geth_networking[idx].port.ws]]
 }
 
 resource "docker_container" "geth" {
@@ -24,7 +25,7 @@ resource "docker_container" "geth" {
     internal = var.geth_networking[count.index].port.raft
   }
   dynamic "ports" {
-    for_each = concat(local.publish_http_ports[count.index], local.publish_ws_ports[count.index], local.publish_graphql_ports[count.index])
+    for_each = concat(local.publish_http_ports[count.index], local.publish_ws_ports[count.index])
     content {
       internal = ports.value["internal"]
       external = ports.value["external"]
@@ -142,10 +143,8 @@ exec geth \
   --wsport ${var.geth_networking[count.index].port.ws.internal} \
   --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,${var.consensus} \
 %{endif~}
-%{if var.geth_networking[count.index].port.graphql != null~}
+%{if var.geth_networking[count.index].graphql~}
   --graphql \
-  --graphql.addr 0.0.0.0 \
-  --graphql.port ${var.geth_networking[count.index].port.graphql.internal} \
 %{endif~}
   --port ${var.geth_networking[count.index].port.p2p} \
   --ethstats "Node${count.index + 1}:${var.ethstats_secret}@${var.ethstats_ip}:${var.ethstats.container.port}" \

--- a/networks/_modules/docker/variables.tf
+++ b/networks/_modules/docker/variables.tf
@@ -28,11 +28,11 @@ variable "geth_networking" {
     port = object({
       http    = object({ internal = number, external = number })
       ws      = object({ internal = number, external = number })
-      graphql = object({ internal = number, external = number })
       p2p     = number
       raft    = number
     })
     ip = object({ private = string, public = string })
+    graphql = bool
   }))
   description = "Networking configuration for `geth` nodes in the network. Number of items must match `tm_networking`"
 }

--- a/networks/_modules/ignite/bootstrap.tf
+++ b/networks/_modules/ignite/bootstrap.tf
@@ -16,7 +16,7 @@ data "null_data_source" "meta" {
     tmKeys          = join(",", [for k in local.tm_named_keys_alloc[count.index] : element(quorum_transaction_manager_keypair.tm.*.key_data, index(local.tm_named_keys_all, k))])
     nodeUrl         = format("http://%s:%d", var.geth_networking[count.index].ip.public, var.geth_networking[count.index].port.http.external)
     tmThirdpartyUrl = format("http://%s:%d", var.tm_networking[count.index].ip.public, var.tm_networking[count.index].port.thirdparty.external)
-    graphqlUrl      = var.geth_networking[count.index].port.graphql != null ? format("http://%s:%d/graphql", var.geth_networking[count.index].ip.public, var.geth_networking[count.index].port.graphql.external) : ""
+    graphqlUrl      = var.geth_networking[count.index].graphql ? format("http://%s:%d/graphql", var.geth_networking[count.index].ip.public, var.geth_networking[count.index].port.http.external) : ""
   }
 }
 

--- a/networks/_modules/ignite/variables.tf
+++ b/networks/_modules/ignite/variables.tf
@@ -8,10 +8,10 @@ variable "geth_networking" {
     port = object({
       http    = object({ internal = number, external = number })
       ws      = object({ internal = number, external = number })
-      graphql = object({ internal = number, external = number })
       p2p     = number
       raft    = number
     })
+    graphql = bool
     ip = object({ private = string, public = string })
   }))
   description = "Networking configuration for `geth` nodes in the network. Number of items must match `tm_networking`"

--- a/networks/plugins/main.tf
+++ b/networks/plugins/main.tf
@@ -35,10 +35,11 @@ module "helper" {
   geth = {
     container = {
       image = var.quorum_docker_image
-      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1, graphql = 8547 }
+      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1 }
+      graphql = true
     }
     host = {
-      port = { http_start = 22000, ws_start = -1, graphql_start = 8001 }
+      port = { http_start = 22000, ws_start = -1}
     }
   }
   tessera = {

--- a/networks/template/main.tf
+++ b/networks/template/main.tf
@@ -23,10 +23,11 @@ module "helper" {
   geth = {
     container = {
       image = var.quorum_docker_image
-      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1, graphql = -1 }
+      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1 }
+      graphql = false
     }
     host = {
-      port = { http_start = 22000, ws_start = -1, graphql_start = -1 }
+      port = { http_start = 22000, ws_start = -1 }
     }
   }
   tessera = {

--- a/networks/typical/main.tf
+++ b/networks/typical/main.tf
@@ -27,10 +27,11 @@ module "helper" {
   geth = {
     container = {
       image = var.quorum_docker_image
-      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1, graphql = 8547 }
+      port  = { raft = 50400, p2p = 21000, http = 8545, ws = -1 }
+      graphql = true
     }
     host = {
-      port = { http_start = 22000, ws_start = -1, graphql_start = 8001 }
+      port = { http_start = 22000, ws_start = -1 }
     }
   }
   tessera = {


### PR DESCRIPTION
**Note: this PR will have to be merged with RED pipeline as the necessary changes are not yet merged in GoQuorum repo. Check the references for the actually pipeline ran with the GoQuorum get 1.9.19 image.**

### Changes

* Remove graphql arguments for port, etc; as now they are the same as the rpc/http arguments (it runs in the same port/host).
* Fix issue with deleting data directory. The problem is that the datadir is deleted while get is still running and only after it, the service is shutdown. However, a new change of 1.9.19 does a cache file of the freeze db while stopping the blockchain service, which then creates the folder again. The solution is to check if `genesis.json` file is there instead of the folder itself (as it might be the folder with this cached db).

_The approach datadir deleting should be reviewed in the future to only be done after the service stops_

### References

* Upgrade: https://github.com/ConsenSys/quorum/pull/1146/
* Pipeline with GoQuorum get 1.9.19 image: TBD