### PR TITLE
improve stability while running in Github Actions

### DIFF
--- a/networks/_modules/docker/ethstats.tf
+++ b/networks/_modules/docker/ethstats.tf
@@ -1,9 +1,10 @@
 
 resource "docker_container" "ethstats" {
+  count      = var.enable_ethstats ? 1 : 0
   depends_on = [docker_image.local, docker_image.registry]
-  image    = var.ethstats.container.image.name
-  name     = format("%s-ethstats", var.network_name)
-  hostname = "ethstats"
+  image      = var.ethstats.container.image.name
+  name       = format("%s-ethstats", var.network_name)
+  hostname   = "ethstats"
   ports {
     internal = var.ethstats.container.port
   }

--- a/networks/_modules/docker/geth.tf
+++ b/networks/_modules/docker/geth.tf
@@ -1,8 +1,8 @@
 locals {
   publish_http_ports = [for idx in local.node_indices : [
-    var.geth_networking[idx].port.http]]
+  var.geth_networking[idx].port.http]]
   publish_ws_ports = var.geth_networking[0].port.ws == null ? [for idx in local.node_indices : []] : [for idx in local.node_indices : [
-    var.geth_networking[idx].port.ws]]
+  var.geth_networking[idx].port.ws]]
 }
 
 resource "docker_container" "geth" {
@@ -155,7 +155,9 @@ exec geth \
   --graphql \
 %{endif~}
   --port ${var.geth_networking[count.index].port.p2p} \
+%{if var.enable_ethstats~}
   --ethstats "Node${count.index + 1}:${var.ethstats_secret}@${var.ethstats_ip}:${var.ethstats.container.port}" \
+%{endif~}
   --unlock ${join(",", range(var.accounts_count[count.index]))} \
   --password ${local.container_geth_datadir}/${var.password_file_name} \
   ${var.consensus == "istanbul" ? "--istanbul.blockperiod 1 --syncmode full --mine --minerthreads 1" : format("--raft --raftport %d", var.geth_networking[count.index].port.raft)} ${var.additional_geth_args} $ADDITIONAL_GETH_ARGS

--- a/networks/_modules/docker/variables.tf
+++ b/networks/_modules/docker/variables.tf
@@ -26,12 +26,12 @@ variable "geth_networking" {
   type = list(object({
     image = object({ name = string, local = bool })
     port = object({
-      http    = object({ internal = number, external = number })
-      ws      = object({ internal = number, external = number })
-      p2p     = number
-      raft    = number
+      http = object({ internal = number, external = number })
+      ws   = object({ internal = number, external = number })
+      p2p  = number
+      raft = number
     })
-    ip = object({ private = string, public = string })
+    ip      = object({ private = string, public = string })
     graphql = bool
   }))
   description = "Networking configuration for `geth` nodes in the network. Number of items must match `tm_networking`"
@@ -67,6 +67,10 @@ variable "ethstats" {
     }
     host = { port = 3000 }
   }
+}
+
+variable "enable_ethstats" {
+  default = false
 }
 
 variable "start_quorum" {


### PR DESCRIPTION
- Pulling `ethstats` Docker image often fails. When running in Github Acttions, we don't need `ethstats`
- `ethstats` can be enabled by setting variable `enable_ethstats` to true