### PR TITLE
make block heights configurable (useful for the network upgrade tests)

### DIFF
--- a/networks/_modules/ignite/bootstrap.tf
+++ b/networks/_modules/ignite/bootstrap.tf
@@ -81,8 +81,14 @@ resource "local_file" "genesis-file" {
       "homesteadBlock": 0,
       "byzantiumBlock": 0,
       "constantinopleBlock":0,
-      "istanbulBlock":0,
-      "petersburgBlock":0,
+      "istanbulBlock":${var.istanbulBlock},
+      "petersburgBlock":${var.petersburgBlock},
+%{if var.muirGlacierBlock != -1 ~}
+      "muirGlacierBlock": ${var.muirGlacierBlock},
+%{endif~}
+%{if var.yoloV1Block != -1 ~}
+      "yoloV1Block": ${var.yoloV1Block},
+%{endif~}
       "chainId": ${random_integer.network_id.result},
       "eip150Block": 0,
       "eip155Block": 0,

--- a/networks/_modules/ignite/variables.tf
+++ b/networks/_modules/ignite/variables.tf
@@ -36,6 +36,26 @@ variable "concensus" {
   description = "Consensus algorithm being used in the network. Supported values are: istanbul and raft"
 }
 
+variable "petersburgBlock" {
+  default     = 0
+  description = "Petersburg block"
+}
+
+variable "istanbulBlock" {
+  default     = 0
+  description = "Istanbul block"
+}
+
+variable "muirGlacierBlock" {
+  default     = -1
+  description = "MuirGlacier block"
+}
+
+variable "yoloV1Block" {
+  default     = -1
+  description = "YoloV1 block"
+}
+
 variable "privacy_enhancements" {
     type        = object({ block = number, enabled = bool })
     default     = { block = 0, enabled = false }

--- a/networks/plugins/main.tf
+++ b/networks/plugins/main.tf
@@ -58,6 +58,10 @@ module "network" {
 
   concensus            = module.helper.consensus
   privacy_enhancements = var.privacy_enhancements
+  petersburgBlock      = var.petersburgBlock
+  istanbulBlock        = var.istanbulBlock
+  muirGlacierBlock     = var.muirGlacierBlock
+  yoloV1Block          = var.yoloV1Block
   network_name         = var.network_name
   geth_networking      = module.helper.geth_networking
   tm_networking        = module.helper.tm_networking

--- a/networks/plugins/variables.tf
+++ b/networks/plugins/variables.tf
@@ -4,6 +4,26 @@ variable "consensus" {
   default = "istanbul"
 }
 
+variable "petersburgBlock" {
+  default     = 0
+  description = "Petersburg block"
+}
+
+variable "istanbulBlock" {
+  default     = 0
+  description = "Istanbul block"
+}
+
+variable "muirGlacierBlock" {
+  default     = -1
+  description = "MuirGlacier block"
+}
+
+variable "yoloV1Block" {
+  default     = -1
+  description = "YoloV1 block"
+}
+
 variable "privacy_enhancements" {
   type        = object({ block = number, enabled = bool })
   default     = { block = 0, enabled = true }

--- a/networks/template/main.tf
+++ b/networks/template/main.tf
@@ -46,6 +46,10 @@ module "network" {
 
   concensus             = module.helper.consensus
   privacy_enhancements  = var.privacy_enhancements
+  petersburgBlock       = var.petersburgBlock
+  istanbulBlock         = var.istanbulBlock
+  muirGlacierBlock      = var.muirGlacierBlock
+  yoloV1Block           = var.yoloV1Block
   network_name          = var.network_name
   geth_networking       = module.helper.geth_networking
   tm_networking         = module.helper.tm_networking

--- a/networks/template/terraform.istanbul-4nodes-pe.tfvars
+++ b/networks/template/terraform.istanbul-4nodes-pe.tfvars
@@ -8,3 +8,6 @@ consensus       = "istanbul"
 docker_images   = ["quorumengineering/quorum:2.5.0", "quorumengineering/tessera:0.10.5"]
 
 privacy_enhancements = { block = 0, enabled = false }
+
+petersburgBlock       = 1000000
+istanbulBlock         = 1000000

--- a/networks/template/terraform.raft-4nodes-pe.tfvars
+++ b/networks/template/terraform.raft-4nodes-pe.tfvars
@@ -8,3 +8,6 @@ consensus       = "raft"
 docker_images   = ["quorumengineering/quorum:2.5.0", "quorumengineering/tessera:0.10.5"]
 
 privacy_enhancements = { block = 0, enabled = false }
+
+petersburgBlock       = 1000000
+istanbulBlock         = 1000000

--- a/networks/template/variables.tf
+++ b/networks/template/variables.tf
@@ -3,6 +3,26 @@
 variable "network_name" {}
 variable "consensus" {}
 
+variable "petersburgBlock" {
+  default     = 0
+  description = "Petersburg block"
+}
+
+variable "istanbulBlock" {
+  default     = 0
+  description = "Istanbul block"
+}
+
+variable "muirGlacierBlock" {
+  default     = -1
+  description = "MuirGlacier block"
+}
+
+variable "yoloV1Block" {
+  default     = -1
+  description = "YoloV1 block"
+}
+
 variable "privacy_enhancements" {
     type        = object({ block = number, enabled = bool })
     default     = { block = 0, enabled = false }

--- a/networks/typical/main.tf
+++ b/networks/typical/main.tf
@@ -50,6 +50,10 @@ module "network" {
 
   concensus            = module.helper.consensus
   privacy_enhancements = var.privacy_enhancements
+  petersburgBlock      = var.petersburgBlock
+  istanbulBlock        = var.istanbulBlock
+  muirGlacierBlock     = var.muirGlacierBlock
+  yoloV1Block          = var.yoloV1Block
   network_name         = var.network_name
   geth_networking      = module.helper.geth_networking
   tm_networking        = module.helper.tm_networking

--- a/networks/typical/variables.tf
+++ b/networks/typical/variables.tf
@@ -2,6 +2,26 @@ variable "consensus" {
   default = "istanbul"
 }
 
+variable "petersburgBlock" {
+  default     = 0
+  description = "Petersburg block"
+}
+
+variable "istanbulBlock" {
+  default     = 0
+  description = "Istanbul block"
+}
+
+variable "muirGlacierBlock" {
+  default     = -1
+  description = "MuirGlacier block"
+}
+
+variable "yoloV1Block" {
+  default     = -1
+  description = "YoloV1 block"
+}
+
 variable "privacy_enhancements" {
     type        = object({ block = number, enabled = bool })
     default     = { block = 0, enabled = false }


### PR DESCRIPTION
In the network upgrade tests (where we start with quorum 2.5.0) where there is a mix of old/new nodes it is useful to be able to configure chain config blocks that the old version is not aware of (petersburg/istanbul) with high values - so that the resulting network can still operate.