### PR TITLE
fix `web3j-maven-plugin` dependency on Ethereum maven repo in Bintray

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ RUN apk -q --no-cache --update add tar bash \
         (apk -q --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community) & \
         p="$!"; pids="$pids $p"; echo "  >> Installing OpenJDK ${JDK_VERSION} - PID $p"; \
         for pid in $pids; do if ! wait "$pid"; then echo "PID Failed: $pid"; exit 1; fi; done) \
-    && echo "  >> Caching Maven Project Dependencies" \
-    && mvn -q dependency:resolve dependency:resolve-plugins \
+    && echo "  >> Caching Maven Project Build" \
+    && mvn -q compile \
     && rm -rf /tmp/downloads
 
-ENTRYPOINT ["mvn", "--no-transfer-progress", "-B"]
+ENTRYPOINT ["mvn", "--no-transfer-progress", "-B", "-DskipToolsCheck", "-DskipGenerateSol"]
 CMD ["test", "-Dtags=basic"]

--- a/extra/solcJ-all-0.4.25.pom
+++ b/extra/solcJ-all-0.4.25.pom
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.ethereum</groupId>
+  <artifactId>solcJ-all</artifactId>
+  <version>0.4.25</version>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,30 @@
                 </configuration>
             </plugin>
             <plugin>
+                <!--
+                    This is a workaround solution:
+                    - `web3j-maven-plugin` has runtime dependency on `solcJ-all` jar which is stored
+                      in ethereum maven repo which is hosted in Bintray
+                    - As Bintray is going to be sunset, we store `solcJ-all` jar locally to avoid
+                      downloading from Bintray
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-solJ-all</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/extra/solcJ-all-0.4.25.jar</file>
+                            <pomFile>${basedir}/extra/solcJ-all-0.4.25.pom</pomFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.thoughtworks.gauge.maven</groupId>
                 <artifactId>gauge-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
- `web3j-maven-plugin` has runtime dependency on `solcJ-all` jar which is stored in ethereum maven repo which is hosted in Bintray
- As Bintray is going to be sunset, we store `solcJ-all` jar locally to avoid downloading from Bintray

Note:
- I tried to update the `web3j-maven-plugin` but the code generation is buggy and unpredictable
- This PR is considered as a workaround solution for the time being