### PR TITLE
fix flaky RPC test due to retry logic not having access token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,5 @@ RUN apk -q --no-cache --update add tar bash \
     && mvn -q compile \
     && rm -rf /tmp/downloads
 
-ENTRYPOINT ["mvn", "--no-transfer-progress", "-B", "-DskipToolsCheck", "-DskipGenerateSol"]
+ENTRYPOINT ["mvn", "--no-transfer-progress", "-B", "-DskipToolsCheck"]
 CMD ["test", "-Dtags=basic"]

--- a/networks/plugins/terraform.istanbul-rpc-security.tfvars
+++ b/networks/plugins/terraform.istanbul-rpc-security.tfvars
@@ -1,9 +1,8 @@
 consensus = "istanbul"
-network_name = "plugins-istanbul"
 plugins = {
   security = {
-    name = "quorum-security-plugin-enterprise"
-    version = "0.1.0"
+    name       = "quorum-security-plugin-enterprise"
+    version    = "0.1.2"
     expose_api = false
   }
 }

--- a/networks/plugins/terraform.raft-rpc-security.tfvars
+++ b/networks/plugins/terraform.raft-rpc-security.tfvars
@@ -1,9 +1,8 @@
-consensus    = "raft"
-network_name = "plugins-raft"
+consensus = "raft"
 plugins = {
   security = {
     name       = "quorum-security-plugin-enterprise"
-    version    = "0.1.0"
+    version    = "0.1.2"
     expose_api = false
   }
 }


### PR DESCRIPTION
- when retrying happens, a different thread is used so access token value must be retained
- fix Dockerfile not to `skipGenerateSol` as Permission spec needs to selectively compile the right Solidity code