### PR TITLE
Update Tessera start command

### DIFF
--- a/networks/_modules/docker-besu/tessera.tf
+++ b/networks/_modules/docker-besu/tessera.tf
@@ -50,8 +50,7 @@ resource "docker_container" "tessera" {
     <<EOF
 echo "Tessera${count.index + 1}"
 
-START_TESSERA="java -Xms128M -Xmx128M \
-  -jar ${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")} \
+START_TESSERA="/home/tessera-extracted/bin/tessera \
   --override jdbc.url=jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0 \
   --override serverConfigs[1].serverAddress="${local.container_tm_q2t_urls[count.index]}" \
   --override serverConfigs[2].sslConfig.serverKeyStore=${local.container_tm_datadir}/serverKeyStore \
@@ -89,8 +88,7 @@ if [ -f /data/tm/cleanStorage ]; then
   fi
 fi
 
-exec java -Xms128M -Xmx128M \
-  -jar ${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")} \
+exec /home/tessera-extracted/bin/tessera \
   --override jdbc.url="jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0" \
   --override serverConfigs[1].serverAddress=${local.container_tm_q2t_urls[count.index]} \
   --override serverConfigs[2].sslConfig.serverKeyStore="${local.container_tm_datadir}/serverKeyStore" \

--- a/networks/_modules/docker-besu/tessera.tf
+++ b/networks/_modules/docker-besu/tessera.tf
@@ -50,19 +50,19 @@ resource "docker_container" "tessera" {
     <<EOF
 echo "Tessera${count.index + 1}"
 
-// TODO: remove following block when Jigsaw dist is default
-FILE="${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")}"
+JAVA_OPTS="-Xms128M -Xmx128M"
+RUN_COMMAND="/home/tessera-extracted/bin/tessera"
 
-if [[ -f "$${FILE}" ]];
+// TODO: remove following block when Jigsaw dist is default
+JAR_FILE="${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")}"
+
+if [[ -f "$${JAR_FILE}" ]];
 then
-  COMMAND="java -Xms128M -Xmx128M -jar $${FILE}"
-else
-  JAVA_OPTS="-Xms128M -Xmx128M"
-  COMMAND="/home/tessera-extracted/bin/tessera"
+  RUN_COMMAND="java -Xms128M -Xmx128M -jar $${JAR_FILE}"
 fi
 // end of block to remove
 
-START_TESSERA="$${COMMAND} \
+START_TESSERA="$${RUN_COMMAND} \
   --override jdbc.url=jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0 \
   --override serverConfigs[1].serverAddress="${local.container_tm_q2t_urls[count.index]}" \
   --override serverConfigs[2].sslConfig.serverKeyStore=${local.container_tm_datadir}/serverKeyStore \

--- a/networks/_modules/docker-besu/tessera.tf
+++ b/networks/_modules/docker-besu/tessera.tf
@@ -50,7 +50,19 @@ resource "docker_container" "tessera" {
     <<EOF
 echo "Tessera${count.index + 1}"
 
-START_TESSERA="/home/tessera-extracted/bin/tessera \
+// TODO: remove following block when Jigsaw dist is default
+FILE="${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")}"
+
+if [[ -f "$${FILE}" ]];
+then
+  COMMAND="java -Xms128M -Xmx128M -jar $${FILE}"
+else
+  JAVA_OPTS="-Xms128M -Xmx128M"
+  COMMAND="/home/tessera-extracted/bin/tessera"
+fi
+// end of block to remove
+
+START_TESSERA="$${COMMAND} \
   --override jdbc.url=jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0 \
   --override serverConfigs[1].serverAddress="${local.container_tm_q2t_urls[count.index]}" \
   --override serverConfigs[2].sslConfig.serverKeyStore=${local.container_tm_datadir}/serverKeyStore \

--- a/networks/_modules/docker-besu/tessera.tf
+++ b/networks/_modules/docker-besu/tessera.tf
@@ -88,16 +88,7 @@ if [ -f /data/tm/cleanStorage ]; then
   fi
 fi
 
-exec /home/tessera-extracted/bin/tessera \
-  --override jdbc.url="jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0" \
-  --override serverConfigs[1].serverAddress=${local.container_tm_q2t_urls[count.index]} \
-  --override serverConfigs[2].sslConfig.serverKeyStore="${local.container_tm_datadir}/serverKeyStore" \
-  --override serverConfigs[2].sslConfig.serverTrustStore="${local.container_tm_datadir}/serverTrustStore" \
-  --override serverConfigs[2].sslConfig.knownClientsFile="${local.container_tm_datadir}/knownClientsFile" \
-  --override serverConfigs[2].sslConfig.clientKeyStore="${local.container_tm_datadir}/clientKeyStore" \
-  --override serverConfigs[2].sslConfig.clientTrustStore="${local.container_tm_datadir}/clientTrustStore" \
-  --override serverConfigs[2].sslConfig.knownServersFile="${local.container_tm_datadir}/knownServersFile" \
-  --configfile ${local.container_tm_datadir}/config.json
+exec $START_TESSERA
 EOF
   ]
 }

--- a/networks/_modules/docker/tessera.tf
+++ b/networks/_modules/docker/tessera.tf
@@ -53,19 +53,19 @@ resource "docker_container" "tessera" {
     <<EOF
 #Tessera${count.index + 1}
 
-// TODO: remove following block when Jigsaw dist is default
-FILE="${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")}"
+JAVA_OPTS="-Xms128M -Xmx128M"
+RUN_COMMAND="/home/tessera-extracted/bin/tessera"
 
-if [[ -f "$${FILE}" ]];
+// TODO: remove following block when Jigsaw dist is default
+JAR_FILE="${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")}"
+
+if [[ -f "$${JAR_FILE}" ]];
 then
-  COMMAND="java -Xms128M -Xmx128M -jar $${FILE}"
-else
-  JAVA_OPTS="-Xms128M -Xmx128M"
-  COMMAND="/home/tessera-extracted/bin/tessera"
+  RUN_COMMAND="java -Xms128M -Xmx128M -jar $${JAR_FILE}"
 fi
 // end of block to remove
 
-START_TESSERA="$${COMMAND} \
+START_TESSERA="$${RUN_COMMAND} \
   --override jdbc.url=jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0 \
   --override serverConfigs[1].serverAddress=unix:${local.container_tm_ipc_file} \
   --override serverConfigs[2].sslConfig.serverKeyStore=${local.container_tm_datadir}/serverKeyStore \

--- a/networks/_modules/docker/tessera.tf
+++ b/networks/_modules/docker/tessera.tf
@@ -53,8 +53,7 @@ resource "docker_container" "tessera" {
     <<EOF
 #Tessera${count.index + 1}
 
-START_TESSERA="java -Xms128M -Xmx128M \
-  -jar ${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")} \
+START_TESSERA="/home/tessera-extracted/bin/tessera \
   --override jdbc.url=jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0 \
   --override serverConfigs[1].serverAddress=unix:${local.container_tm_ipc_file} \
   --override serverConfigs[2].sslConfig.serverKeyStore=${local.container_tm_datadir}/serverKeyStore \
@@ -93,8 +92,7 @@ if [ -f /data/tm/cleanStorage ]; then
 fi
 
 rm -f ${local.container_tm_ipc_file}
-exec java -Xms128M -Xmx128M \
-  -jar ${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")} \
+exec /home/tessera-extracted/bin/tessera \
   --override jdbc.url="jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0" \
   --override serverConfigs[1].serverAddress="unix:${local.container_tm_ipc_file}" \
   --override serverConfigs[2].sslConfig.serverKeyStore="${local.container_tm_datadir}/serverKeyStore" \

--- a/networks/_modules/docker/tessera.tf
+++ b/networks/_modules/docker/tessera.tf
@@ -92,16 +92,7 @@ if [ -f /data/tm/cleanStorage ]; then
 fi
 
 rm -f ${local.container_tm_ipc_file}
-exec /home/tessera-extracted/bin/tessera \
-  --override jdbc.url="jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0" \
-  --override serverConfigs[1].serverAddress="unix:${local.container_tm_ipc_file}" \
-  --override serverConfigs[2].sslConfig.serverKeyStore="${local.container_tm_datadir}/serverKeyStore" \
-  --override serverConfigs[2].sslConfig.serverTrustStore="${local.container_tm_datadir}/serverTrustStore" \
-  --override serverConfigs[2].sslConfig.knownClientsFile="${local.container_tm_datadir}/knownClientsFile" \
-  --override serverConfigs[2].sslConfig.clientKeyStore="${local.container_tm_datadir}/clientKeyStore" \
-  --override serverConfigs[2].sslConfig.clientTrustStore="${local.container_tm_datadir}/clientTrustStore" \
-  --override serverConfigs[2].sslConfig.knownServersFile="${local.container_tm_datadir}/knownServersFile" \
-  --configfile ${local.container_tm_datadir}/config.json
+exec $START_TESSERA
 EOF
   ]
 }

--- a/networks/_modules/docker/tessera.tf
+++ b/networks/_modules/docker/tessera.tf
@@ -53,7 +53,19 @@ resource "docker_container" "tessera" {
     <<EOF
 #Tessera${count.index + 1}
 
-START_TESSERA="/home/tessera-extracted/bin/tessera \
+// TODO: remove following block when Jigsaw dist is default
+FILE="${lookup(var.tessera_app_container_path, count.index, "/tessera/tessera-app.jar")}"
+
+if [[ -f "$${FILE}" ]];
+then
+  COMMAND="java -Xms128M -Xmx128M -jar $${FILE}"
+else
+  JAVA_OPTS="-Xms128M -Xmx128M"
+  COMMAND="/home/tessera-extracted/bin/tessera"
+fi
+// end of block to remove
+
+START_TESSERA="$${COMMAND} \
   --override jdbc.url=jdbc:h2:${local.container_tm_datadir}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0 \
   --override serverConfigs[1].serverAddress=unix:${local.container_tm_ipc_file} \
   --override serverConfigs[2].sslConfig.serverKeyStore=${local.container_tm_datadir}/serverKeyStore \


### PR DESCRIPTION
During development of the Tessera Jigsaw impl (https://github.com/ConsenSys/tessera/pull/1200), the entrypoint used to start Tessera is different, but this is overriden in the Terraform scripts.

This PR adds a temporary solution by defaulting to the existing jar file (or one the user specifies), and if it doesn't exist, then uses the location expected for the Jigsaw dist.

Once the Tessera changes are merged, this change can be updated to default to the start script or the user defined location.

Note: the start script that the Jigsaw dish uses is actually just the gradle generated start script.