### PR TITLE
[Fix] update public tx estimation to the right one post istanbul

### DIFF
--- a/src/specs/01_basic/estimate_gas.spec
+++ b/src/specs/01_basic/estimate_gas.spec
@@ -24,4 +24,4 @@ EstimateGas api call should return valid 'close' estimate of required gas.
 ## Estimate gas required for zero value public transaction
 
 * Estimate gas for public transaction transferring zero Wei from a default account in "Node1" to a default account in "Node2"
-* Gas estimate "25352" is returned within "10" percent
+* Gas estimate "22024" is returned within "10" percent


### PR DESCRIPTION
### Summary

Update as per fix done on https://github.com/ConsenSys/quorum/pull/1195.

NOTE: already tested locally but on the pipeline won't get green that test as fix is not yet merged in GoQ (it will only be merged after).

### Changes

* Change the public estimated gas to match the Istanbul fork when a tx value is 0 and could contain a PTM hash.
