### PR TITLE
Ignore spam tests for Besu

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -127,7 +127,7 @@ jobs:
             privacy-enhancements: 'true'
           - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
             privacy-enhancements: 'true'
-          - tag: '(basic && !privacy-enhancements-disabled && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2'
+          - tag: '(basic && !privacy-enhancements-disabled && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed && !spam) || networks/typical-besu::ibft2'
             privacy-enhancements: 'false'
             besu-network: 'true'
     runs-on: ubuntu-18.04

--- a/src/specs/01_basic/private_smart_contract_spam.spec
+++ b/src/specs/01_basic/private_smart_contract_spam.spec
@@ -1,6 +1,6 @@
 # Multiple private smart contracts between nodes
 
- Tags: basic
+ Tags: basic, spam
 
 ## Send transactions from one node to others
 


### PR DESCRIPTION
### Summary

As ethSigner doesn't support well handling the nonce management, we are skipping this test for Besu.

### Changes

* Add new `spam` tag
* Ignore the `spam` tag from the Besu CI/CD job.