### PR TITLE
Add new AT that tests the network migration with freezerdb data

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -109,6 +109,8 @@ jobs:
           - 'basic-rpc-security || networks/plugins::istanbul-rpc-security'
           - 'migration && networks/template::raft-4nodes'
           - 'migration && networks/template::istanbul-4nodes'
+          - 'migration && networks/template::raft-4nodes-ancientdb'
+          - 'migration && networks/template::istanbul-4nodes-ancientdb'
           - 'permissions-v1 && networks/template::raft-3plus1'
           - 'permissions-v2 && networks/template::raft-3plus1'
           - 'privacy-enhancements-upgrade || networks/template::raft-4nodes-pe'

--- a/networks/template/terraform.istanbul-4nodes-ancientdb.tfvars
+++ b/networks/template/terraform.istanbul-4nodes-ancientdb.tfvars
@@ -1,0 +1,11 @@
+#
+#  This network setups with 4 nodes
+#
+
+number_of_nodes = 4
+consensus = "istanbul"
+# Import images so they can be used programatically in the test
+docker_images = [
+    "quorumengineering/quorum:20.10.0",
+    "quorumengineering/quorum:21.4.0"]
+addtional_geth_args = "--immutabilitythreshold 3 --allow-insecure-unlock"

--- a/networks/template/terraform.raft-4nodes-ancientdb.tfvars
+++ b/networks/template/terraform.raft-4nodes-ancientdb.tfvars
@@ -1,0 +1,11 @@
+#
+#  This network setups with 4 nodes
+#
+
+number_of_nodes = 4
+consensus = "raft"
+# Import images so they can be used programatically in the test
+docker_images = [
+    "quorumengineering/quorum:20.10.0",
+    "quorumengineering/quorum:21.4.0"]
+addtional_geth_args = "--immutabilitythreshold 3 --allow-insecure-unlock"

--- a/src/main/java/com/quorum/gauge/services/UtilService.java
+++ b/src/main/java/com/quorum/gauge/services/UtilService.java
@@ -25,12 +25,15 @@ import com.quorum.gauge.ext.PendingTransaction;
 import io.reactivex.Observable;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthBlockNumber;
 import org.web3j.protocol.core.methods.response.NetPeerCount;
 import org.web3j.protocol.core.methods.response.Transaction;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +51,11 @@ public class UtilService extends AbstractService {
     public Observable<EthBlockNumber> getCurrentBlockNumberFrom(QuorumNode node) {
         Web3j client = connectionFactory().getWeb3jConnection(node);
         return client.ethBlockNumber().flowable().toObservable();
+    }
+
+    public Observable<EthBlock> getBlockByNumber(QuorumNode node, int number) {
+        Web3j client = connectionFactory().getWeb3jConnection(node);
+        return client.ethGetBlockByNumber(DefaultBlockParameter.valueOf(BigInteger.valueOf(number)), false).flowable().toObservable();
     }
 
     public List<Transaction> getPendingTransactions(QuorumNode node) {

--- a/src/specs/02_advanced/network_migration_ancientdb.spec
+++ b/src/specs/02_advanced/network_migration_ancientdb.spec
@@ -1,12 +1,12 @@
-# Network migration from one version to the later version of `geth`
+# Network migration from one version with data in ancient db (freezerdb) to the later version of `geth`
 
- Tags: networks/template::raft-4nodes, networks/template::istanbul-4nodes, migration, pre-condition/no-record-blocknumber
+ Tags: networks/template::raft-4nodes-ancientdb, networks/template::istanbul-4nodes-ancientdb, migration, pre-condition/no-record-blocknumber
 
 In this spec, we assume that all nodes in the network are initially in the same version and together
-upgradable to the new version
+upgradable to the new version. Also, the immutability threshold is 3 for ancient db
 
         | from_version | to_version |
-        | v2.5.0       | develop     |
+        | 20.10.0       | develop    |
 
 * Start the network with:
     | node  | quorum         | tessera |
@@ -15,8 +15,12 @@ upgradable to the new version
     | Node2 | <from_version> | develop  |
     | Node3 | <from_version> | develop  |
     | Node4 | <from_version> | develop  |
-* Use SimpleStorage smart contract, populate network with "500" public transactions randomly between "Node1,Node2,Node3,Node4"
+* Use SimpleStorage smart contract, populate network with "30" public transactions randomly between "Node1,Node2,Node3,Node4" with "1" of threads per node
 * Record the current block number, named it as "recordedBlockNumber"
+* Wait for node "Node1" to catch up to block number "6"
+* Check if we are able to get the block number "6" from "Node1"
+* Check if we are able to get the block number "2" from "Node1"
+
 
 ## Migrate all nodes in the network at the same time
 
@@ -32,6 +36,10 @@ upgradable to the new version
 * Verify block number in "Node1,Node2,Node3,Node4" in sync with "recordedBlockNumber"
 * Use SimpleStorage smart contract, populate network with "10" public transactions randomly between "Node1,Node2,Node3,Node4"
 * Network is running
+* Check if we are able to get the block number "2" from "Node1"
+* Check if we are able to get the block number "2" from "Node2"
+* Check if we are able to get the block number "2" from "Node3"
+* Check if we are able to get the block number "2" from "Node4"
 
 ## Migrate node by node in the network
 
@@ -39,11 +47,19 @@ upgradable to the new version
 
 * Stop and start "quorum" in "Node1" using <to_version>
 * Verify block number in "Node1" in sync with "recordedBlockNumber"
+* Check if we are able to get the block number "2" from "Node1"
 * Stop and start "quorum" in "Node2" using <to_version>
 * Verify block number in "Node2" in sync with "recordedBlockNumber"
+* Check if we are able to get the block number "2" from "Node2"
 * Stop and start "quorum" in "Node3" using <to_version>
 * Verify block number in "Node3" in sync with "recordedBlockNumber"
+* Check if we are able to get the block number "2" from "Node3"
 * Stop and start "quorum" in "Node4" using <to_version>
 * Verify block number in "Node4" in sync with "recordedBlockNumber"
+* Check if we are able to get the block number "2" from "Node4"
 * Use SimpleStorage smart contract, populate network with "10" public transactions randomly between "Node1,Node2,Node3,Node4"
 * Network is running
+* Check if we are able to get the block number "2" from "Node1"
+* Check if we are able to get the block number "2" from "Node2"
+* Check if we are able to get the block number "2" from "Node3"
+* Check if we are able to get the block number "2" from "Node4"

--- a/src/test/java/com/quorum/gauge/BlockSynchronization.java
+++ b/src/test/java/com/quorum/gauge/BlockSynchronization.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthBlockNumber;
 import org.web3j.tx.Contract;
 
@@ -81,25 +82,25 @@ public class BlockSynchronization extends AbstractSpecImplementation {
 
     public void startQuorumNetwork(String networkType, String id, List<Node> nodes, String gcmode, String permissionVersion) {
         GethArgBuilder additionalGethArgs = GethArgBuilder.newBuilder()
-                .permissioned("permissioned".equalsIgnoreCase(networkType))
-                .gcmode(gcmode);
+            .permissioned("permissioned".equalsIgnoreCase(networkType))
+            .gcmode(gcmode);
 
         NetworkResources networkResources = new NetworkResources();
         try {
             Observable.fromIterable(nodes)
-                    .flatMap(n -> infraService.startNode(
-                            NodeAttributes.forNode(n.getName()).withAdditionalGethArgs(additionalGethArgs),
-                            resourceId -> networkResources.add(n.getName(), resourceId)
-                    ))
-                    .doOnNext(ok -> {
-                        assertThat(ok).as("Node must start successfully").isTrue();
-                    })
-                    .doOnComplete(() -> {
-                        Duration gracePeriod = networkProperty.getConsensusGracePeriod();
-                        logger.debug("Waiting {}s for network to be up completely...", gracePeriod.toSeconds());
-                        Thread.sleep(gracePeriod.toMillis());
-                    })
-                    .blockingSubscribe();
+                .flatMap(n -> infraService.startNode(
+                    NodeAttributes.forNode(n.getName()).withAdditionalGethArgs(additionalGethArgs),
+                    resourceId -> networkResources.add(n.getName(), resourceId)
+                ))
+                .doOnNext(ok -> {
+                    assertThat(ok).as("Node must start successfully").isTrue();
+                })
+                .doOnComplete(() -> {
+                    Duration gracePeriod = networkProperty.getConsensusGracePeriod();
+                    logger.debug("Waiting {}s for network to be up completely...", gracePeriod.toSeconds());
+                    Thread.sleep(gracePeriod.toMillis());
+                })
+                .blockingSubscribe();
         } finally {
             DataStoreFactory.getScenarioDataStore().put("networkResources", networkResources);
         }
@@ -127,27 +128,27 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         // fire 5 public and 5 private txs
         for (Node n : nodes) {
             parallelSender.add(sendTxs(n, txCountPerNode, threadsPerNode, null)
-                    .subscribeOn(Schedulers.io()));
+                .subscribeOn(Schedulers.io()));
             parallelSender.add(sendTxs(n, txCountPerNode, threadsPerNode, randomNode(nodes, n))
-                    .subscribeOn(Schedulers.io()));
+                .subscribeOn(Schedulers.io()));
         }
         Observable.zip(parallelSender, oks -> true)
-                .doOnComplete(() -> {
-                    BigInteger currentBlockNumber = utilService.getCurrentBlockNumber().blockingFirst().getBlockNumber();
-                    logger.debug("Current block number = {}", currentBlockNumber);
-                    DataStoreFactory.getScenarioDataStore().put(latestBlockHeightName, currentBlockNumber);
-                })
-                .blockingSubscribe();
+            .doOnComplete(() -> {
+                BigInteger currentBlockNumber = utilService.getCurrentBlockNumber().blockingFirst().getBlockNumber();
+                logger.debug("Current block number = {}", currentBlockNumber);
+                DataStoreFactory.getScenarioDataStore().put(latestBlockHeightName, currentBlockNumber);
+            })
+            .blockingSubscribe();
     }
 
 
     private Observable<? extends Contract> sendTxs(Node n, int txCountPerNode, int threadsPerNode, Node target) {
         return Observable.range(0, txCountPerNode)
-                .doOnNext(c -> logger.debug("Sending tx {} to {}", c, n))
-                .flatMap(v -> Observable.just(v)
-                                .flatMap(num -> contractService.createSimpleContract(40, n, target))
-                                .subscribeOn(Schedulers.io())
-                        , threadsPerNode);
+            .doOnNext(c -> logger.debug("Sending tx {} to {}", c, n))
+            .flatMap(v -> Observable.just(v)
+                    .flatMap(num -> contractService.createSimpleContract(40, n, target))
+                    .subscribeOn(Schedulers.io())
+                , threadsPerNode);
     }
 
     private Node randomNode(List<Node> nodes, Node n) {
@@ -178,12 +179,13 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         nodes.stream().forEach(n -> {
             logger.debug("istanbul.propose targetNode:{} fromNode:{} vote:{} nodeAddr:{}", targetNode.getName(), n.getName(), vote, nodeAddr);
             istanbulService.propose(QuorumNode.valueOf(n.getName()), nodeAddr, vote)
-                    .doOnNext(res -> {
-                        Response.Error err2 = Optional.ofNullable(res.getError()).orElse(new Response.Error());
-                        assertThat(err2.getMessage()).as("istanbul.propose must succeed").isBlank();
-                    }).blockingSubscribe();
+                .doOnNext(res -> {
+                    Response.Error err2 = Optional.ofNullable(res.getError()).orElse(new Response.Error());
+                    assertThat(err2.getMessage()).as("istanbul.propose must succeed").isBlank();
+                }).blockingSubscribe();
         });
     }
+
     @Step("Add new node, named it <newNode>, and join the network <id> as <nodeType>")
     public void addNewNode(Node newNode, String id, NodeType nodeType) {
         addNewNode(null, newNode, id, nodeType);
@@ -196,27 +198,27 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         switch (networkProperty.getConsensus()) {
             case "raft":
                 raftService.addPeer(networkResources.aNodeName(), newNode.getEnodeUrl(), nodeType)
-                        .doOnNext(res -> {
-                            Response.Error err = Optional.ofNullable(res.getError()).orElse(new Response.Error());
-                            assertThat(err.getMessage()).as("raft.add" + nodeType.name() + " must succeed").isBlank();
-                            if (nodeType == NodeType.learner)
-                                DataStoreFactory.getScenarioDataStore().put(newNode.getName() + "_raftId", res.getResult());
-                        })
-                        .map(Response::getResult)
-                        .flatMap(raftId -> infraService.startNode(
-                                NodeAttributes.forNode(newNode.getName())
-                                        .withAdditionalGethArgs(additionalGethArgs.raftjoinexisting(raftId).gcmode(gcmode)),
-                                resourceId -> networkResources.add(newNode.getName(), resourceId)
-                        ))
-                        .blockingSubscribe();
+                    .doOnNext(res -> {
+                        Response.Error err = Optional.ofNullable(res.getError()).orElse(new Response.Error());
+                        assertThat(err.getMessage()).as("raft.add" + nodeType.name() + " must succeed").isBlank();
+                        if (nodeType == NodeType.learner)
+                            DataStoreFactory.getScenarioDataStore().put(newNode.getName() + "_raftId", res.getResult());
+                    })
+                    .map(Response::getResult)
+                    .flatMap(raftId -> infraService.startNode(
+                        NodeAttributes.forNode(newNode.getName())
+                            .withAdditionalGethArgs(additionalGethArgs.raftjoinexisting(raftId).gcmode(gcmode)),
+                        resourceId -> networkResources.add(newNode.getName(), resourceId)
+                    ))
+                    .blockingSubscribe();
                 break;
             case "istanbul":
                 // this node is non-validator node, just start it up
                 infraService.startNode(
-                        NodeAttributes.forNode(newNode.getName())
-                                .withAdditionalGethArgs(additionalGethArgs.gcmode(gcmode)),
-                        resourceId -> networkResources.add(newNode.getName(), resourceId))
-                        .blockingSubscribe();
+                    NodeAttributes.forNode(newNode.getName())
+                        .withAdditionalGethArgs(additionalGethArgs.gcmode(gcmode)),
+                    resourceId -> networkResources.add(newNode.getName(), resourceId))
+                    .blockingSubscribe();
                 break;
             default:
                 throw new UnsupportedOperationException(networkProperty.getConsensus() + " not supported yet");
@@ -224,20 +226,20 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         // update static-nodes.json and permissioned-nodes.json from all the nodes
         // including the new node we just started
         Observable.fromIterable(networkResources.allResourceIds())
-                .filter(containerId -> infraService.isGeth(containerId).blockingFirst())
-                .doOnNext(gethContainerId -> logger.debug("Modifying files in container {}", StringUtils.substring(gethContainerId, 0, 12)))
-                .flatMap(gethContainerId -> infraService.modifyFile(gethContainerId,
-                        "/data/qdata/static-nodes.json",
-                        InfrastructureService.JSONListModifier.with(newNode.getEnodeUrl())))
-                .flatMap(gethContainerId -> infraService.modifyFile(gethContainerId,
-                        "/data/qdata/permissioned-nodes.json",
-                        InfrastructureService.JSONListModifier.with(newNode.getEnodeUrl())))
-                .doOnComplete(() -> {
-                    Duration duration = networkProperty.getConsensusGracePeriod();
-                    logger.debug("Waiting {}s while network reflects new modification ...", duration.getSeconds());
-                    Thread.sleep(duration.toMillis());
-                })
-                .blockingSubscribe();
+            .filter(containerId -> infraService.isGeth(containerId).blockingFirst())
+            .doOnNext(gethContainerId -> logger.debug("Modifying files in container {}", StringUtils.substring(gethContainerId, 0, 12)))
+            .flatMap(gethContainerId -> infraService.modifyFile(gethContainerId,
+                "/data/qdata/static-nodes.json",
+                InfrastructureService.JSONListModifier.with(newNode.getEnodeUrl())))
+            .flatMap(gethContainerId -> infraService.modifyFile(gethContainerId,
+                "/data/qdata/permissioned-nodes.json",
+                InfrastructureService.JSONListModifier.with(newNode.getEnodeUrl())))
+            .doOnComplete(() -> {
+                Duration duration = networkProperty.getConsensusGracePeriod();
+                logger.debug("Waiting {}s while network reflects new modification ...", duration.getSeconds());
+                Thread.sleep(duration.toMillis());
+            })
+            .blockingSubscribe();
     }
 
     @Step("Verify node <node> has the block height greater or equal to <latestBlockHeightName>")
@@ -275,13 +277,29 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         DataStoreFactory.getScenarioDataStore().put(name, currentBlockNumber);
     }
 
+    @Step("Check if we are able to get the block number <number> from <node>")
+    public void getBlockNumberFromNode(int number, QuorumNode node) {
+        EthBlock.Block block = utilService.getBlockByNumber(node, number).blockingFirst().getBlock();
+        logger.debug("Block = {}", block);
+        assertThat(block).isNotNull();
+    }
+
     @Step("Wait for node <node> to catch up to <block>")
     public void waitForNodeToReachBlockNumber(Node node, String name) {
         final BigInteger lastBlockHeight = mustHaveValue(DataStoreFactory.getScenarioDataStore(), name, BigInteger.class);
+        this.waitForNodeToReachBlockNumber(node, lastBlockHeight);
+    }
+
+    @Step("Wait for node <node> to catch up to block number <block>")
+    public void waitForNodeToReachBlockNumber(Node node, int blockNum) {
+        this.waitForNodeToReachBlockNumber(node, BigInteger.valueOf(blockNum));
+    }
+
+    public void waitForNodeToReachBlockNumber(Node node, BigInteger blockNumber) {
         BigInteger currentBlockHeight = utilService.getCurrentBlockNumberFrom(node).blockingFirst().getBlockNumber();
         int i = 0;
         final int MAX_COUNT = 20;
-        while (currentBlockHeight.compareTo(lastBlockHeight) < 0) {
+        while (currentBlockHeight.compareTo(blockNumber) < 0) {
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException e) {
@@ -298,8 +316,8 @@ public class BlockSynchronization extends AbstractSpecImplementation {
     public void stopAllNodes(String id) {
         NetworkResources networkResources = mustHaveValue(DataStoreFactory.getScenarioDataStore(), "networkResources", NetworkResources.class);
         Observable.fromIterable(networkResources.allResourceIds())
-                .flatMap(infraService::stopResource)
-                .blockingSubscribe();
+            .flatMap(infraService::stopResource)
+            .blockingSubscribe();
     }
 
     @Step("Start all nodes in the network <id>")
@@ -307,20 +325,20 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         NetworkResources networkResources = mustHaveValue(DataStoreFactory.getScenarioDataStore(), "networkResources", NetworkResources.class);
         // start all nodes
         Observable.fromIterable(networkResources.allResourceIds())
-                .flatMap(infraService::startResource)
-                .blockingSubscribe();
+            .flatMap(infraService::startResource)
+            .blockingSubscribe();
         // wait for them to be healthy
         Observable.fromIterable(networkResources.allResourceIds())
-                .flatMap(infraService::wait)
-                .doOnNext(ok -> {
-                    assertThat(ok).as("Node must be up").isTrue();
-                })
-                .doOnComplete(() -> {
-                    Duration duration = networkProperty.getConsensusGracePeriod();
-                    logger.debug("Waiting {}s for network to be up completely...", duration.toSeconds());
-                    Thread.sleep(duration.toMillis());
-                })
-                .blockingSubscribe();
+            .flatMap(infraService::wait)
+            .doOnNext(ok -> {
+                assertThat(ok).as("Node must be up").isTrue();
+            })
+            .doOnComplete(() -> {
+                Duration duration = networkProperty.getConsensusGracePeriod();
+                logger.debug("Waiting {}s for network to be up completely...", duration.toSeconds());
+                Thread.sleep(duration.toMillis());
+            })
+            .blockingSubscribe();
         logger.debug("started all nodes");
     }
 
@@ -329,11 +347,11 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         BigInteger expectedBlockNumber = mustHaveValue(DataStoreFactory.getScenarioDataStore(), blockHeightName, BigInteger.class);
         NetworkResources networkResources = mustHaveValue(DataStoreFactory.getScenarioDataStore(), "networkResources", NetworkResources.class);
         Observable.fromIterable(networkResources.getNodeNames())
-                .doOnNext(n -> {
-                    EthBlockNumber b = utilService.getCurrentBlockNumberFrom(networkProperty.getNode(n)).blockingFirst();
-                    assertThat(b.getBlockNumber()).as("Block number from node " + n).isGreaterThanOrEqualTo(expectedBlockNumber);
-                })
-                .blockingSubscribe();
+            .doOnNext(n -> {
+                EthBlockNumber b = utilService.getCurrentBlockNumberFrom(networkProperty.getNode(n)).blockingFirst();
+                assertThat(b.getBlockNumber()).as("Block number from node " + n).isGreaterThanOrEqualTo(expectedBlockNumber);
+            })
+            .blockingSubscribe();
     }
 
     @Step("<nodeName> is able to seal new blocks")
@@ -356,9 +374,9 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         Duration longerDuration = Duration.ofSeconds(networkProperty.getConsensusGracePeriod().getSeconds() * 2);
         logger.debug("Grepping '{}' in the log stream for {}s ...", expectedLogMsg, longerDuration.getSeconds());
         Boolean found = Observable.fromIterable(networkResources.get(nodeName.getName()))
-                .filter(id -> infraService.isGeth(id).blockingFirst())
-                .flatMap(id -> infraService.grepLog(id, expectedLogMsg, longerDuration.getSeconds(), TimeUnit.SECONDS))
-                .blockingFirst();
+            .filter(id -> infraService.isGeth(id).blockingFirst())
+            .flatMap(id -> infraService.grepLog(id, expectedLogMsg, longerDuration.getSeconds(), TimeUnit.SECONDS))
+            .blockingFirst();
 
         assertThat(found).as(expectedLogMsg).isTrue();
     }
@@ -369,11 +387,11 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         switch (networkProperty.getConsensus()) {
             case "raft":
                 raftService.promoteToPeer(fromNode.getName(), raftId)
-                        .doOnNext(res -> {
-                            Response.Error err = Optional.ofNullable(res.getError()).orElse(new Response.Error());
-                            assertThat(err.getMessage()).as("raft.promoteToPeer must succeed").isBlank();
-                            assertThat(res.getResult()).isTrue();
-                        }).blockingSubscribe();
+                    .doOnNext(res -> {
+                        Response.Error err = Optional.ofNullable(res.getError()).orElse(new Response.Error());
+                        assertThat(err.getMessage()).as("raft.promoteToPeer must succeed").isBlank();
+                        assertThat(res.getResult()).isTrue();
+                    }).blockingSubscribe();
                 break;
             default:
                 throw new UnsupportedOperationException(networkProperty.getConsensus() + " not supported yet");
@@ -436,19 +454,19 @@ public class BlockSynchronization extends AbstractSpecImplementation {
         NetworkResources networkResources = new NetworkResources();
         try {
             Observable.fromIterable(nodes)
-                    .flatMap(n -> infraService.startNode(
-                            NodeAttributes.forNode(n.getName()).withAdditionalGethArgs(additionalGethArgs),
-                            resourceId -> networkResources.add(n.getName(), resourceId)
-                    ))
-                    .doOnNext(ok -> {
-                        assertThat(ok).as("Node must start successfully").isTrue();
-                    })
-                    .doOnComplete(() -> {
-                        Duration gracePeriod = networkProperty.getConsensusGracePeriod();
-                        logger.debug("Waiting {}s for network to be up completely...", gracePeriod.toSeconds());
-                        Thread.sleep(gracePeriod.toMillis());
-                    })
-                    .blockingSubscribe();
+                .flatMap(n -> infraService.startNode(
+                    NodeAttributes.forNode(n.getName()).withAdditionalGethArgs(additionalGethArgs),
+                    resourceId -> networkResources.add(n.getName(), resourceId)
+                ))
+                .doOnNext(ok -> {
+                    assertThat(ok).as("Node must start successfully").isTrue();
+                })
+                .doOnComplete(() -> {
+                    Duration gracePeriod = networkProperty.getConsensusGracePeriod();
+                    logger.debug("Waiting {}s for network to be up completely...", gracePeriod.toSeconds());
+                    Thread.sleep(gracePeriod.toMillis());
+                })
+                .blockingSubscribe();
         } finally {
             DataStoreFactory.getScenarioDataStore().put("networkResources", networkResources);
         }

--- a/src/test/java/com/quorum/gauge/NetworkMigration.java
+++ b/src/test/java/com/quorum/gauge/NetworkMigration.java
@@ -132,12 +132,16 @@ public class NetworkMigration extends AbstractSpecImplementation {
         }
     }
 
-    @Step("Use SimpleStorage smart contract, populate network with <publicTxCount> public transactions and <privateTxCount> private transactions randomly between <nodesStr>")
-    public void deploySimpleStorageContract(int publicTxCount, int privateTxCount, String nodesStr) {
+    @Step("Use SimpleStorage smart contract, populate network with <publicTxCount> public transactions randomly between <nodesStr>")
+    public void deploySimpleStoragePublicContract(int publicTxCount, String nodesStr) {
+        this.deploySimpleStoragePublicContract(publicTxCount, nodesStr, 10);
+    }
+
+    @Step("Use SimpleStorage smart contract, populate network with <publicTxCount> public transactions randomly between <nodesStr> with <number> of threads per node")
+    public void deploySimpleStoragePublicContract(int publicTxCount, String nodesStr,int threadsPerNode) {
         List<String> nodes = Arrays.stream(nodesStr.split(",")).map(String::trim).collect(Collectors.toList());
-        int threadsPerNode = 10;
         // build calls for public transactions
-        // fire to each node in parallel, max 10 threads for each node
+        // fire to each node in parallel, max <threadsPerNode>> threads for each node
         int txCountPerNode = (int) Math.round(Math.ceil((double)publicTxCount / nodes.size()));
         if (txCountPerNode < threadsPerNode) {
             threadsPerNode = txCountPerNode;


### PR DESCRIPTION
### Summary

This test replicates this issue https://github.com/ConsenSys/quorum/issues/1179.

### Changes

* Added a new test with a low immutability threshold to force the client to move data to the freezer db.
* Test after migration that we can still access blocks saved on the freezer db.