### PR TITLE
ci/cd: make Besu network fail if tests fail, remove the skip checks

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -122,7 +122,7 @@ jobs:
           - 'basic || networks/typical::istanbulmps'
           - 'mps-upgrade-txtrace || networks/template::raft-4nodes-mps'
           - 'mps-upgrade-txtrace || networks/template::istanbul-4nodes-mps'
-          - '(basic && !privacy-enhancements-disabled && !nosupport && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2'
+          - '(basic && !privacy-enhancements-disabled && !mps && !nosupport && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2'
         privacy-enhancements:
           - 'false'
         include:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -122,7 +122,7 @@ jobs:
           - 'basic || networks/typical::istanbulmps'
           - 'mps-upgrade-txtrace || networks/template::raft-4nodes-mps'
           - 'mps-upgrade-txtrace || networks/template::istanbul-4nodes-mps'
-          - '(basic && !privacy-enhancements-disabled && !mps && !nosupport && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2'
+          - '(basic && !nosupport && !mps && !spam && !eth-api-signed && !privacy-enhancements-disabled && !graphql && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2'
         privacy-enhancements:
           - 'false'
         include:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -122,6 +122,7 @@ jobs:
           - 'basic || networks/typical::istanbulmps'
           - 'mps-upgrade-txtrace || networks/template::raft-4nodes-mps'
           - 'mps-upgrade-txtrace || networks/template::istanbul-4nodes-mps'
+          - '(basic && !privacy-enhancements-disabled && !nosupport && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2'
         privacy-enhancements:
           - 'false'
         include:
@@ -129,9 +130,6 @@ jobs:
             privacy-enhancements: 'true'
           - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
             privacy-enhancements: 'true'
-          - tag: '(basic && !privacy-enhancements-disabled && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed && !spam) || networks/typical-besu::ibft2'
-            privacy-enhancements: 'false'
-            besu-network: 'true'
     runs-on: ubuntu-18.04
     steps:
       - name: 'Download docker image'
@@ -192,7 +190,6 @@ jobs:
           echo "::set-output name=outputDir::${{ runner.temp }}"
           echo "::set-output name=dockerEnvFile::$dockerEnvFile"
       - name: 'Run tests using ${{ needs.condition.outputs.infra }}'
-        continue-on-error: ${{ matrix.besu-network == 'true' }}
         run: |
           # we don't remove the container after run as we need to clean up the infra if used
           docker run \
@@ -207,7 +204,6 @@ jobs:
                 -Dauto.jobid=${{ steps.setup.outputs.tag }}
       - name: 'Failure info'
         if: ${{ failure() }}
-        continue-on-error: ${{ matrix.besu-network == 'true' }}
         run: |
             echo "acceptance tests failures"
             docker images
@@ -215,7 +211,6 @@ jobs:
             for containerId in $(docker ps -qa); do echo "container: $containerId"; docker container inspect $containerId; docker container logs $containerId; done
       - name: 'Read test report'
         if: always()
-        continue-on-error: ${{ matrix.besu-network == 'true' }}
         run: |
           failuresRaw="$(cat ${{ steps.setup.outputs.outputDir }}/failures.txt | jq -r '.[] | @base64')"
           SAVEIFS=$IFS   # Save current IFS
@@ -234,14 +229,12 @@ jobs:
           cat ${{ steps.setup.outputs.outputDir}}/summary.txt
       - name: 'Upload test report'
         if: always()
-        continue-on-error: ${{ matrix.besu-network == 'true' }}
         uses: actions/upload-artifact@v2
         with:
           name: testreport-${{ steps.setup.outputs.tag }}
           path: ${{ steps.setup.outputs.outputDir }}/*.* # only files not directory
       - name: 'Destroy infrastructure resources if ever created'
         if: always() && needs.condition.outputs.use_aws == 'true'
-        continue-on-error: ${{ matrix.besu-network == 'true' }}
         # we don't care about containers running on the remote VM
         run: |
           docker commit acctests-run quorumengineering/acctests:after

--- a/networks/_modules/docker-helper/variables.tf
+++ b/networks/_modules/docker-helper/variables.tf
@@ -42,7 +42,7 @@ variable "tessera" {
   })
   default = {
     container = {
-      image = { name = "quorumengineering/tessera:latest", local = false }
+      image = { name = "quorumengineering/tessera:develop", local = false }
       port  = { thirdparty = 9080, p2p = 9000, q2t = 9081 }
     }
     host = {
@@ -64,7 +64,7 @@ variable "besu" {
   })
   default = {
     container = {
-      image = { name = "hyperledger/besu:latest", local = false }
+      image = { name = "hyperledger/besu:develop", local = false }
       port  = { http = 8545, ws= 8546, graphql= 8547, p2p= 30303 }
     }
     host = {

--- a/networks/_modules/docker-helper/variables.tf
+++ b/networks/_modules/docker-helper/variables.tf
@@ -86,7 +86,7 @@ variable "ethsigner" {
   })
   default = {
     container = {
-      image = { name = "consensys/quorum-ethsigner:latest", local = false }
+      image = { name = "consensys/quorum-ethsigner:develop", local = false }
       port  = 8545
     }
     host = {

--- a/networks/typical-besu/variables.tf
+++ b/networks/typical-besu/variables.tf
@@ -45,7 +45,7 @@ variable "tessera_docker_image" {
 
 variable "ethsigner_docker_image" {
   type        = object({ name = string, local = bool })
-  default     = { name = "consensys/quorum-ethsigner:latest", local = false }
+  default     = { name = "consensys/quorum-ethsigner:develop", local = false }
   description = "Local=true indicates that the image is already available locally and don't need to pull from registry"
 }
 

--- a/networks/typical-besu/variables.tf
+++ b/networks/typical-besu/variables.tf
@@ -33,13 +33,13 @@ variable "number_of_nodes" {
 
 variable "besu_docker_image" {
   type        = object({ name = string, local = bool })
-  default     = { name = "hyperledger/besu:latest", local = false }
+  default     = { name = "hyperledger/besu:develop", local = false }
   description = "Local=true indicates that the image is already available locally and don't need to pull from registry"
 }
 
 variable "tessera_docker_image" {
   type        = object({ name = string, local = bool })
-  default     = { name = "quorumengineering/tessera:latest", local = false }
+  default     = { name = "quorumengineering/tessera:develop", local = false }
   description = "Local=true indicates that the image is already available locally and don't need to pull from registry"
 }
 

--- a/src/test/java/com/quorum/gauge/PrivateStateValidation.java
+++ b/src/test/java/com/quorum/gauge/PrivateStateValidation.java
@@ -227,9 +227,12 @@ public class PrivateStateValidation extends AbstractSpecImplementation {
         TransactionReceipt receipt = nestedContractService.updateC2Contract(
             source,
             Arrays.stream(privateFor.split(",")).map(s -> QuorumNode.valueOf(s)).collect(Collectors.toList()),
-            c.getContractAddress(), newValue,  Arrays.asList(PrivacyFlag.StandardPrivate)).blockingFirst();
+            c.getContractAddress(), newValue, Arrays.asList(PrivacyFlag.StandardPrivate)).blockingFirst();
 
         assertThat(receipt.getTransactionHash()).isNotBlank();
         assertThat(receipt.getBlockNumber()).isNotEqualTo(currentBlockNumber());
+
+        TransactionReceipt receiptPrivateFor = transactionService.waitForTransactionReceipt(QuorumNode.valueOf(privateFor), receipt.getTransactionHash());
+        assertThat(receiptPrivateFor.getBlockNumber()).isNotEqualTo(currentBlockNumber());
     }
 }


### PR DESCRIPTION
### Changes

* Remove ignore job from the GithubAction configuration on Quorum Acceptance tests project to make the job fail when the tests fail
* Update Besu, EthSigner and Tessera tags to `develop`.
* Reduce flakiness