### PR TITLE
Enable PMT tests & run extra feature networks in separate workflow

### DIFF
--- a/.github/workflows/run-extra.yml
+++ b/.github/workflows/run-extra.yml
@@ -1,4 +1,5 @@
-name: Run Acceptance Tests on standard networks
+# Exactly the same setup and teardown steps as run.yml, just different test tags
+name: Run Acceptance Tests on extra feature-enabled networks
 on:
   schedule:
     - cron: '0 12 * * *'
@@ -85,7 +86,7 @@ jobs:
     # This workflow uses tag expression and its sha256 hash to aggregate test results
     # from each execution. It is important that the job name has tag expression in the
     # suffix and encapsulated within parathensis
-    name: Tests tagged with (${{ matrix.tag }})
+    name: Test (${{ matrix.tag }}) (privacy-enhancements=${{matrix.privacy-enhancements}}, privacy-precompile=${{matrix.privacy-precompile}}, privacy-marker-transactions=${{matrix.privacy-marker-transactions}})
     if: needs.condition.outputs.should_run == 'true'
     needs:
       - condition
@@ -94,45 +95,70 @@ jobs:
       fail-fast: false
       matrix:
         # list of tag expression being executed in parallel
-        tag:
-          - 'basic || basic-raft || (advanced && raft) || networks/typical::raft'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/typical::qbft'
-          - 'gcmode && block-sync && networks/template::raft-3plus1'
-          - 'gcmode && block-sync && networks/template::istanbul-3plus1'
-          - 'gcmode && block-sync && networks/template::qbft-3plus1'
-          - 'learner-peer-management || raftdnsenable && networks/template::raft-3plus1'
-          - 'validator-management && networks/template::qbft-3plus1'
-          - 'validator-management && networks/template::istanbul-3plus1'
-          - 'qbft-transition-network && networks/template::qbft-4nodes-transition'
-          - 'basic || basic-raft || (advanced && raft) || networks/plugins::raft'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/plugins::qbft'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/plugins::istanbul'
-          - 'basic || basic-raft || (advanced && raft) || networks/plugins::raft-account-plugin-hashicorp-vault'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/plugins::qbft-account-plugin-hashicorp-vault'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/plugins::istanbul-account-plugin-hashicorp-vault'
-          - 'basic-rpc-security || networks/plugins::raft-rpc-security'
-          - 'basic-rpc-security || networks/plugins::qbft-rpc-security'
-          - 'basic-rpc-security || networks/plugins::istanbul-rpc-security'
-          - 'migration && networks/template::raft-4nodes'
-          - 'migration && networks/template::istanbul-4nodes'
-          - 'migration && networks/template::raft-4nodes-ancientdb'
-          - 'migration && networks/template::istanbul-4nodes-ancientdb'
-          - 'permissions-v1 && networks/template::raft-3plus1'
-          - 'permissions-v2 && networks/template::raft-3plus1'
-          - 'privacy-enhancements-upgrade || networks/template::raft-4nodes-pe'
-          - 'privacy-enhancements-upgrade || networks/template::istanbul-4nodes-pe'
-          - 'multitenancy && networks/plugins::raft-multitenancy'
-          - 'basic || basic-raft || (advanced && raft) || networks/typical::raft-simple-mps'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/typical::qbft-simple-mps'
-          - 'basic || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul-simple-mps'
-          - 'basic || networks/typical::raftmps'
-          - 'basic || networks/typical::qbftmps'
-          - 'basic || networks/typical::istanbulmps'
-          - 'mps-upgrade-txtrace || networks/template::raft-4nodes-mps'
-          - 'mps-upgrade-txtrace || networks/template::istanbul-4nodes-mps'
-          - '(basic && !nosupport && !mps && !(spam && !raw) && !eth-api-signed && !privacy-enhancements-disabled && !graphql && !async && !extension && !storage-root && !personal-api-signed) || networks/typical-besu::ibft2'
-          - '(basic && !nosupport && !mps && !(spam && !raw) && !eth-api-signed && !privacy-enhancements-disabled && !graphql && !async && !extension && !storage-root && !personal-api-signed) || networks/typical-hybrid::hybrid'
+        include:
+          # privacy enhancements tests
+          - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || basic-raft || (advanced && raft) || networks/typical::raft'
+            privacy-enhancements: true
+            privacy-precompile: false
+            privacy-marker-transactions: false
+          - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
+            privacy-enhancements: true
+            privacy-precompile: false
+            privacy-marker-transactions: false
+          # privacy precompile/privacy marker transaction tests
+          - tag: 'basic || basic-raft || (advanced && raft) || networks/typical::raft'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: false
+          - tag: 'basic || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: false
+          - tag: 'basic || basic-istanbul || (advanced && istanbul) || networks/typical::qbft'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: false
+          - tag: '(multitenancy || privacy-precompile-enabled) && networks/plugins::raft-multitenancy'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-precompile-disabled) || basic-raft || (advanced && raft) || networks/typical::raft-simple-mps'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-precompile-disabled) || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul-simple-mps'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-precompile-disabled) || basic-istanbul || (advanced && istanbul) || networks/typical::qbft-simple-mps'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-precompile-disabled) || networks/typical::raftmps'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-precompile-disabled) || networks/typical::istanbulmps'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-precompile-disabled) || networks/typical::qbftmps'
+            privacy-enhancements: false
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          # privacy enhancements + privacy precompile/privacy marker transaction tests
+          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || privacy-precompile-enabled || basic-raft || (advanced && raft) || networks/typical::raft'
+            privacy-enhancements: true
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || privacy-precompile-enabled || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
+            privacy-enhancements: true
+            privacy-precompile: true
+            privacy-marker-transactions: true
+          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || privacy-precompile-enabled || basic-istanbul || (advanced && istanbul) || networks/typical::qbft'
+            privacy-enhancements: true
+            privacy-precompile: true
+            privacy-marker-transactions: true
     runs-on: ubuntu-18.04
     steps:
       - name: 'Download docker image'
@@ -159,7 +185,6 @@ jobs:
             local_image="false"
           fi
           dockerEnvFile=${{ runner.temp }}/env.list
-          touch $dockerEnvFile # create empty dockerEnvFile just in case we don't echo anything to it
           # now we check if we should use the custom docker images in this repo
           gitref_path="${{ github.ref }}"
           gitref_path=${gitref_path/refs\/heads\//} # for refs/heads/my-branch
@@ -187,6 +212,9 @@ jobs:
               echo "TF_VAR_docker_registry=[{name=\"docker.pkg.github.com\", username=\"${{ github.repository_owner }}\", password=\"${{ github.token }}\"}]" >> $dockerEnvFile
             fi
           fi
+          echo "TF_VAR_privacy_enhancements={block=0, enabled=${{ matrix.privacy-enhancements}}}" >> $dockerEnvFile
+          echo "TF_VAR_privacy_precompile={block=0, enabled=${{ matrix.privacy-precompile}}}" >> $dockerEnvFile
+          echo "TF_VAR_privacy_marker_transactions=${{ matrix.privacy-marker-transactions}}" >> $dockerEnvFile
           echo "::set-output name=tag::$tagKey"
           echo "::set-output name=mvnArg::$mvnArg"
           echo "::set-output name=dockerEnv::$dockerEnv"
@@ -208,20 +236,20 @@ jobs:
       - name: 'Failure info'
         if: ${{ failure() }}
         run: |
-            echo "Docker container info"
-            set -x
-            docker images
-            docker ps -a
-            set +x
+          echo "Docker container info"
+          set -x
+          docker images
+          docker ps -a
+          set +x
 
-            IFS=$'\n' # set internal field separator so we can iterate over docker ps output
-            for CONTAINER in $(docker ps -a --format {{.Names}})
-            do
-              echo "writing logs for $CONTAINER to ${CONTAINER}.log"
-              docker logs $CONTAINER > ${{ steps.setup.outputs.outputDir }}/${CONTAINER}.log 2>&1
-              echo "writing inspect output for $CONTAINER to ${CONTAINER}-inspect.json"
-              docker container inspect $CONTAINER > ${{ steps.setup.outputs.outputDir }}/${CONTAINER}-inspect.json 2>&1
-            done
+          IFS=$'\n' # set internal field separator so we can iterate over docker ps output
+          for CONTAINER in $(docker ps -a --format {{.Names}})
+          do
+            echo "writing logs for $CONTAINER to ${CONTAINER}.log"
+            docker logs $CONTAINER > ${{ steps.setup.outputs.outputDir }}/${CONTAINER}.log 2>&1
+            echo "writing inspect output for $CONTAINER to ${CONTAINER}-inspect.json"
+            docker container inspect $CONTAINER > ${{ steps.setup.outputs.outputDir }}/${CONTAINER}-inspect.json 2>&1
+          done
       - name: 'Read test report'
         if: always()
         run: |

--- a/networks/plugins/variables.tf
+++ b/networks/plugins/variables.tf
@@ -6,7 +6,7 @@ variable "consensus" {
 
 variable "privacy_enhancements" {
   type        = object({ block = number, enabled = bool })
-  default     = { block = 0, enabled = true }
+  default     = { block = 0, enabled = false }
   description = "privacy enhancements state (enabled/disabled) and the block height at which they are enabled"
 }
 


### PR DESCRIPTION
Enable the PMT tests and split up the increasing number of tests into 2 workflows.  There are still a few flaky tests to be addressed and increasing the number of tests run increases the chances of one of these tests failing which requires a complete rerun of the entire suite.  Splitting the tests into multiple workflows allows rerunning a smaller suite of tests.

`.github/workflows/run-extra.yml` is exactly the same as `.github/workflows/run.yml` except it also sets the terraform variables for privacy enhancement and privacy precompile/privacy marker transaction networks, and obviously runs a different matrix of test tags.

GitHub Actions does not yet support sharing/importing workflows hence the large amount of copy-paste.

We may wish to further split tests out into different workflows to ease/speed development.