### PR TITLE
Hybrid validator management

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -104,6 +104,8 @@ jobs:
           - 'learner-peer-management || raftdnsenable && networks/template::raft-3plus1'
           - 'validator-management && networks/template::qbft-3plus1'
           - 'validator-management && networks/template::istanbul-3plus1'
+          - 'hybrid-validator-management-manage-besu && networks/typical-hybrid::hybrid-template-q2b1'
+          - 'hybrid-validator-management-manage-quorum && networks/typical-hybrid::hybrid-template-q1b2'
           - 'qbft-transition-network && networks/template::qbft-4nodes-transition'
           - 'basic || basic-raft || (advanced && raft) || networks/plugins::raft'
           - 'basic || basic-istanbul || (advanced && istanbul) || networks/plugins::qbft'

--- a/networks/_modules/docker-besu/besu.tf
+++ b/networks/_modules/docker-besu/besu.tf
@@ -14,8 +14,8 @@ resource "docker_container" "besu" {
   image      = var.besu_networking[count.index].image.name
   hostname   = format("node%d", count.index)
   restart    = "no"
-  must_run   = true
-  start      = true
+  must_run   = local.must_start[count.index]
+  start      = local.must_start[count.index]
   labels {
     label = "BesuContainer"
     value = count.index
@@ -89,8 +89,13 @@ exec /opt/besu/bin/besu \
         --privacy-url="${local.container_tm_q2t_urls[count.index]}" \
         --privacy-public-key-file=${local.container_besu_datadir}/tmkey.pub \
         --privacy-onchain-groups-enabled=false \
-        --rpc-http-api=EEA,WEB3,ETH,MINER,NET,PRIV,PERM,GOQUORUM,IBFT \
-        --rpc-ws-api=EEA,WEB3,ETH,MINER,NET,PRIV,PERM,GOQUORUM,IBFT ;
+%{if var.hybrid_network~}
+        --rpc-http-api=ADMIN,EEA,WEB3,ETH,MINER,NET,PRIV,PERM,GOQUORUM,QBFT \
+        --rpc-ws-api=ADMIN,EEA,WEB3,ETH,MINER,NET,PRIV,PERM,GOQUORUM,QBFT ;
+%{else~}
+        --rpc-http-api=ADMIN,EEA,WEB3,ETH,MINER,NET,PRIV,PERM,GOQUORUM,IBFT \
+        --rpc-ws-api=ADMIN,EEA,WEB3,ETH,MINER,NET,PRIV,PERM,GOQUORUM,IBFT ;
+%{endif~}
 EOF
   }
 }

--- a/networks/_modules/docker-besu/ethsigner.tf
+++ b/networks/_modules/docker-besu/ethsigner.tf
@@ -10,8 +10,8 @@ resource "docker_container" "ethsigner" {
   image      = var.ethsigner_networking[count.index].image.name
   hostname   = format("ethsigner_node%d", count.index)
   restart    = "no"
-  must_run   = true
-  start      = true
+  must_run   = var.start_ethsigner
+  start      = var.start_ethsigner
   labels {
     label = "ethsignerContainer"
     value = count.index

--- a/networks/_modules/docker-besu/main.tf
+++ b/networks/_modules/docker-besu/main.tf
@@ -12,7 +12,12 @@ locals {
 
   node_indices             = range(local.number_of_nodes) // 0-based node index
   tessera_node_indices     = var.hybrid_network ? [for id in range(local.number_of_nodes) : sum([id, local.quorum_nodes])] : range(local.number_of_nodes)
-  node_initial_paticipants = { for id in local.node_indices : id => "true" } // default to true for all
+
+  node_initial_paticipants = merge(
+  { for id in local.node_indices : id => "true" }, // default to true for all
+  { for id in var.exclude_initial_nodes : id => "false" }
+  )
+  must_start = [for idx in local.node_indices : tobool(lookup(local.node_initial_paticipants, idx, "false")) && tobool(var.start_besu)]
 
   tm_env = [for k, v in var.tm_env : "${k}=${v}"]
 }

--- a/networks/_modules/docker-besu/tessera.tf
+++ b/networks/_modules/docker-besu/tessera.tf
@@ -6,8 +6,8 @@ resource "docker_container" "tessera" {
   hostname          = format("tm%d", local.tessera_node_indices[count.index])
   restart           = "no"
   publish_all_ports = false
-  must_run          = true
-  start             = true
+  must_run          = var.start_tessera
+  start             = var.start_tessera
   labels {
     label = "TesseraContainer"
     value = local.tessera_node_indices[count.index]

--- a/networks/_modules/docker-besu/variables.tf
+++ b/networks/_modules/docker-besu/variables.tf
@@ -101,6 +101,23 @@ variable "hybrid_network" {
 }
 
 variable "number_of_quorum_nodes" {
-  default = 0
+  default     = 0
   description = "Number of quorum nodes in the hybrid network"
+}
+
+variable "exclude_initial_nodes" {
+  default     = []
+  description = "Exclude nodes (0-based index) from initial list of participants. E.g: [3, 4, 5] to exclude Node4, Node5, and Node6 from the initial participants of the network"
+}
+
+variable "start_besu" {
+  default = true
+}
+
+variable "start_ethsigner" {
+  default = true
+}
+
+variable "start_tessera" {
+  default = true
 }

--- a/networks/_modules/ignite-besu/main.tf
+++ b/networks/_modules/ignite-besu/main.tf
@@ -31,15 +31,18 @@ locals {
   // this can be overrriden by the variable
   named_accounts_alloc = { for id in local.node_indices : id => [
   "Default"] }
-  tm_named_keys_all        = flatten(values(local.tm_named_keys_alloc))
-  node_initial_paticipants = { for id in local.node_indices : id => "true" }
-  istanbul_validators      = { for id in local.node_indices : id => "true" }
-  hybrid_network           = var.hybrid_network
+  tm_named_keys_all = flatten(values(local.tm_named_keys_alloc))
+  node_initial_paticipants = merge(
+    { for id in local.node_indices : id => "true" }, // default to true for all
+    { for id in var.exclude_initial_nodes : id => "false" }
+  )
+  istanbul_validators = { for id in local.node_indices : id => "true" }
+  hybrid_network      = var.hybrid_network
 
   key_data       = var.hybrid_network ? var.hybrid_key_data : quorum_transaction_manager_keypair.tm.*.key_data
   public_key_b64 = var.hybrid_network ? var.hybrid_public_key_b64 : quorum_transaction_manager_keypair.tm.*.public_key_b64
 
-  total_node_indices     = var.hybrid_network ? [for id in range(local.number_of_nodes) : sum([id, local.number_of_quorum_nodes])] : range(local.number_of_nodes)
+  total_node_indices = var.hybrid_network ? [for id in range(local.number_of_nodes) : sum([id, local.number_of_quorum_nodes])] : range(local.number_of_nodes)
 }
 
 resource "random_string" "network-name" {

--- a/networks/_modules/ignite-besu/outputs.tf
+++ b/networks/_modules/ignite-besu/outputs.tf
@@ -45,3 +45,7 @@ output "keystore_files" {
 output "keystore_password_file" {
   value = local.keystore_password_file
 }
+
+output "exclude_initial_nodes" {
+  value = var.exclude_initial_nodes
+}

--- a/networks/_modules/ignite-besu/variables.tf
+++ b/networks/_modules/ignite-besu/variables.tf
@@ -82,26 +82,31 @@ variable "hybrid_node_key" {
 }
 
 variable "hybrid_configuration_filename" {
-  default = ""
+  default     = ""
   description = "Configuration filename for hybrid network"
 }
 
 variable "hybrid_tmkeys" {
-  default = []
+  default     = []
   description = "tmkeys to be used for hybrid network"
 }
 
 variable "hybrid_public_key_b64" {
-  default = []
+  default     = []
   description = "tessera public key in base64 encoding for hybrid network"
 }
 
 variable "hybrid_key_data" {
-  default = []
+  default     = []
   description = "tessera key data for hybrid network"
 }
 
 variable "number_of_quorum_nodes" {
-  default = 0
+  default     = 0
   description = "Number of quorum nodes in the hybrid network"
+}
+
+variable "exclude_initial_nodes" {
+  default     = []
+  description = "Exclude nodes (0-based index) from initial list of participants. E.g: [3, 4, 5] to exclude Node4, Node5, and Node6 from the initial participants of the network"
 }

--- a/networks/typical-hybrid/bootstrap.tf
+++ b/networks/typical-hybrid/bootstrap.tf
@@ -1,5 +1,5 @@
 locals {
-  besu_addr   = [for idx in local.besu_node_indices : quorum_bootstrap_node_key.besu-nodekeys-generator[idx].istanbul_address if lookup(local.istanbul_validators, idx, "false") == "true"]
+  besu_addr   = [for idx in local.besu_node_indices : quorum_bootstrap_node_key.besu-nodekeys-generator[idx].istanbul_address if lookup(local.istanbul_validators, idx + local.number_of_quorum_nodes, "false") == "true"]
   quorum_addr = [for idx in local.quorum_node_indices : quorum_bootstrap_node_key.quorum-nodekeys-generator[idx].istanbul_address if lookup(local.istanbul_validators, idx, "false") == "true"]
 
   besu_alloc   = formatlist("\"%s\" : { \"balance\": \"%s\" }", quorum_bootstrap_keystore.besu-accountkeys-generator[*].account[0].address, quorum_bootstrap_keystore.besu-accountkeys-generator[*].account[0].balance)
@@ -109,11 +109,15 @@ quorum:
   nodes:
 %{for i in data.null_data_source.meta[*].inputs.idx~}
     ${format("Node%d:", i + 1)}
-      istanbul-validator-id: ${quorum_bootstrap_istanbul_extradata.hybrid.istanbul_addresses[i]}
+%{if i < local.number_of_quorum_nodes~}
+      istanbul-validator-id: ${quorum_bootstrap_node_key.quorum-nodekeys-generator[i].istanbul_address}
+%{else~}
+      istanbul-validator-id: ${quorum_bootstrap_node_key.besu-nodekeys-generator[i - local.number_of_quorum_nodes].istanbul_address}
+%{endif~}
       enode-url: ${local.enode_urls[i]}
       account-aliases:
 %{for idx, k in local.named_accounts_alloc[i]~}
-%{if i < local.number_of_quorum_nodes ~}
+%{if i < local.number_of_quorum_nodes~}
         ${k}: "${element(quorum_bootstrap_keystore.quorum-accountkeys-generator[i].account.*.address, idx)}"
 %{else~}
         ${k}: "${element(quorum_bootstrap_keystore.besu-accountkeys-generator[i - local.number_of_quorum_nodes].account.*.address, idx)}"

--- a/networks/typical-hybrid/files.tf
+++ b/networks/typical-hybrid/files.tf
@@ -50,6 +50,11 @@ resource "local_file" "dockerwaitmain" {
 # These are properties being used by DockerWait Spring Boot application.
 # 'docker' profile is activated in order to allow the application perform health checking on the containers.
 
+# template network we don't need to do health check
+%{if var.template_network == true~}
+wait.disable = true
+%{endif~}
+
 spring.profiles.active = ${var.network_name},docker
 spring.config.additional-location = file:${module.network.generated_dir}/
 
@@ -62,8 +67,11 @@ resource "local_file" "gauge_env" {
   content  = <<EOT
 
 # These are environment variables being used by Gauge while running the tests.
-
+%{if var.template_network == true~}
+SPRING_PROFILES_ACTIVE = ${var.network_name},docker%{if var.remote_docker_config != null~},proxy%{endif}
+%{else~}
 SPRING_PROFILES_ACTIVE = ${var.network_name}%{if var.remote_docker_config != null~},proxy%{endif}
+%{endif~}
 SPRING_CONFIG_ADDITIONALLOCATION = file:${module.network.generated_dir}/
 
 EOT

--- a/networks/typical-hybrid/terraform.hybrid-template-q1b2.tfvars
+++ b/networks/typical-hybrid/terraform.hybrid-template-q1b2.tfvars
@@ -1,0 +1,15 @@
+#
+#  This network setups a hybrid network template with 2 quorum and 2 besu nodes and excludes 2nd quorum node
+#
+
+// Exclude 2nd quorum node. Using exclude_initial_nodes for simplicity, it is only used to evaluate istanbul_validators
+exclude_initial_quorum_nodes = [1]
+exclude_initial_nodes        = [1]
+number_of_quorum_nodes       = 2
+number_of_besu_nodes         = 2
+consensus                    = "qbft"
+qbftBlock                    = { block = 0, enabled = true }
+start_quorum                 = false
+start_besu                   = false
+start_tessera                = false
+template_network             = true

--- a/networks/typical-hybrid/terraform.hybrid-template-q2b1.tfvars
+++ b/networks/typical-hybrid/terraform.hybrid-template-q2b1.tfvars
@@ -1,0 +1,15 @@
+#
+#  This network setups a hybrid network template with 2 quorum and 2 besu nodes and excludes 2nd besu node
+#
+
+// Exclude 2nd besu node. Using exclude_initial_nodes for simplicity, it is only used to evaluate istanbul_validators
+exclude_initial_besu_nodes = [1]
+exclude_initial_nodes      = [3]
+number_of_quorum_nodes     = 2
+number_of_besu_nodes       = 2
+consensus                  = "qbft"
+qbftBlock                  = { block = 0, enabled = true }
+start_quorum               = false
+start_besu                 = false
+start_tessera              = false
+template_network           = true

--- a/networks/typical-hybrid/variables.tf
+++ b/networks/typical-hybrid/variables.tf
@@ -3,9 +3,9 @@ variable "consensus" {
 }
 
 variable "privacy_enhancements" {
-    type        = object({ block = number, enabled = bool })
-    default     = { block = 0, enabled = false }
-    description = "privacy enhancements state (enabled/disabled) and the block height at which they are enabled"
+  type        = object({ block = number, enabled = bool })
+  default     = { block = 0, enabled = false }
+  description = "privacy enhancements state (enabled/disabled) and the block height at which they are enabled"
 }
 
 variable "privacy_precompile" {
@@ -47,17 +47,17 @@ variable "gauge_env_outdir" {
 //---------- advanced inputs -----------
 variable "number_of_quorum_nodes" {
   description = "Number of quorum nodes"
-  default = 2
+  default     = 2
 }
 
 variable "number_of_besu_nodes" {
   description = "Number of besu nodes"
-  default = 2
+  default     = 2
 }
 
 variable "hybrid-network" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "true if it a besu-quorum hybrid network"
 }
 
@@ -111,19 +111,19 @@ variable "besu" {
   type = object({
     container = object({
       image = object({ name = string, local = bool })
-      port  = object({ http = number, ws = number,graphql = number, p2p = number })
+      port  = object({ http = number, ws = number, graphql = number, p2p = number })
     })
     host = object({
-      port = object({ http_start = number,ws_start = number,graphql_start = number })
+      port = object({ http_start = number, ws_start = number, graphql_start = number })
     })
   })
   default = {
     container = {
       image = { name = "hyperledger/besu:develop", local = false }
-      port  = { http = 8545, ws= 8546, graphql= 8547, p2p= 21000 }
+      port  = { http = 8545, ws = 8546, graphql = 8547, p2p = 21000 }
     }
     host = {
-      port = { http_start = 22000 , ws_start= 23100, graphql_start= 23200 }
+      port = { http_start = 22000, ws_start = 23100, graphql_start = 23200 }
     }
   }
   description = "besu Docker container configuration "
@@ -157,8 +157,8 @@ variable "docker_registry" {
 }
 
 variable "additional_quorum_container_vol" {
-  type = map(list(object({container_path = string, host_path = string})))
-  default = {}
+  type        = map(list(object({ container_path = string, host_path = string })))
+  default     = {}
   description = "Additional volume mounts for geth container. Each map key is the node index (0-based)"
 }
 
@@ -194,4 +194,35 @@ EOT
 variable "exclude_initial_nodes" {
   default     = []
   description = "Exclude nodes (0-based index) from initial list of participants. E.g: [3, 4, 5] to exclude Node4, Node5, and Node6 from the initial participants of the network"
+}
+
+variable "exclude_initial_besu_nodes" {
+  default     = []
+  description = "Exclude nodes (0-based index) from initial list of besu participants. E.g: [3, 4, 5] to exclude Node4, Node5, and Node6 from the initial participants of the network"
+}
+
+variable "exclude_initial_quorum_nodes" {
+  default     = []
+  description = "Exclude nodes (0-based index) from initial list of quorum participants. E.g: [3, 4, 5] to exclude Node4, Node5, and Node6 from the initial participants of the network"
+}
+
+variable "start_quorum" {
+  default = true
+}
+
+variable "start_tessera" {
+  default = true
+}
+
+variable "start_besu" {
+  default = true
+}
+
+variable "start_ethsigner" {
+  default = true
+}
+
+variable "template_network" {
+  description = "variable to represent a template network"
+  default     = false
 }

--- a/src/main/java/com/quorum/gauge/ext/NodeInfo.java
+++ b/src/main/java/com/quorum/gauge/ext/NodeInfo.java
@@ -52,5 +52,14 @@ public class NodeInfo extends Response<LinkedHashMap<Object, Object>> {
 
         return "";
     }
+    public String getName() {
+        final LinkedHashMap<Object, Object> result = this.getResult();
+
+        if ((result == null) || (result.get("name") == null)) {
+            return null;
+        }
+
+        return result.get("name").toString();
+    }
 
 }

--- a/src/main/java/com/quorum/gauge/ext/NodeInfo.java
+++ b/src/main/java/com/quorum/gauge/ext/NodeInfo.java
@@ -52,14 +52,5 @@ public class NodeInfo extends Response<LinkedHashMap<Object, Object>> {
 
         return "";
     }
-    public String getName() {
-        final LinkedHashMap<Object, Object> result = this.getResult();
-
-        if ((result == null) || (result.get("name") == null)) {
-            return null;
-        }
-
-        return result.get("name").toString();
-    }
 
 }

--- a/src/main/java/com/quorum/gauge/services/BesuQBFTService.java
+++ b/src/main/java/com/quorum/gauge/services/BesuQBFTService.java
@@ -1,6 +1,6 @@
 package com.quorum.gauge.services;
 
-import com.quorum.gauge.common.QuorumNode;
+import com.quorum.gauge.common.QuorumNetworkProperty;
 import com.quorum.gauge.ext.IstanbulNodeAddress;
 import com.quorum.gauge.ext.IstanbulPropose;
 import io.reactivex.Observable;
@@ -22,7 +22,7 @@ public class BesuQBFTService extends AbstractService {
      * @param vote
      * @return
      */
-    public Observable<IstanbulPropose> propose(final QuorumNode node, final String proposedValidatorAddress, boolean vote) {
+    public Observable<IstanbulPropose> propose(final QuorumNetworkProperty.Node node, final String proposedValidatorAddress, boolean vote) {
         logger.debug("Node {} proposing {}", node, proposedValidatorAddress);
 
         return new Request<>(
@@ -38,7 +38,7 @@ public class BesuQBFTService extends AbstractService {
      * @param node
      * @return
      */
-    public Observable<IstanbulNodeAddress> nodeAddress(final QuorumNode node) {
+    public Observable<IstanbulNodeAddress> nodeAddress(final QuorumNetworkProperty.Node node) {
         logger.debug("node address of node {}", node);
         return new Request<>(
             "eth_coinbase",

--- a/src/main/java/com/quorum/gauge/services/BesuQBFTService.java
+++ b/src/main/java/com/quorum/gauge/services/BesuQBFTService.java
@@ -1,0 +1,50 @@
+package com.quorum.gauge.services;
+
+import com.quorum.gauge.common.QuorumNode;
+import com.quorum.gauge.ext.IstanbulNodeAddress;
+import com.quorum.gauge.ext.IstanbulPropose;
+import io.reactivex.Observable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.web3j.protocol.core.Request;
+
+import java.util.Arrays;
+
+@Service
+public class BesuQBFTService extends AbstractService {
+    private static final Logger logger = LoggerFactory.getLogger(BesuQBFTService.class);
+
+    /**
+     * propose proposes the given node to be added as a validator if vote is true and remove as a validator if vote is false
+     * @param node
+     * @param proposedValidatorAddress
+     * @param vote
+     * @return
+     */
+    public Observable<IstanbulPropose> propose(final QuorumNode node, final String proposedValidatorAddress, boolean vote) {
+        logger.debug("Node {} proposing {}", node, proposedValidatorAddress);
+
+        return new Request<>(
+            "qbft_proposeValidatorVote",
+            Arrays.asList(proposedValidatorAddress, vote),
+            connectionFactory().getWeb3jService(node),
+            IstanbulPropose.class
+        ).flowable().toObservable();
+    }
+
+    /**
+     * nodeAddress returns the QBFT validator address
+     * @param node
+     * @return
+     */
+    public Observable<IstanbulNodeAddress> nodeAddress(final QuorumNode node) {
+        logger.debug("node address of node {}", node);
+        return new Request<>(
+            "eth_coinbase",
+            Arrays.asList(),
+            connectionFactory().getWeb3jService(node),
+            IstanbulNodeAddress.class
+        ).flowable().toObservable();
+    }
+}

--- a/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
+++ b/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
@@ -260,6 +260,14 @@ public class DockerInfrastructureService
                 .map(l -> l.containsKey("QuorumContainer"));
     }
 
+    @Override
+    public Observable<Boolean> isBesu(String resourceId) {
+        return Observable.just(dockerClient.inspectContainerCmd(resourceId).exec())
+            .map(InspectContainerResponse::getConfig)
+            .map(ContainerConfig::getLabels)
+            .map(l -> l.containsKey("BesuContainer"));
+    }
+
     /**
      * Datadir in docker network is {@code /data/qdata}
      * @param networkResources

--- a/src/main/java/com/quorum/gauge/services/InfrastructureService.java
+++ b/src/main/java/com/quorum/gauge/services/InfrastructureService.java
@@ -61,6 +61,8 @@ public interface InfrastructureService {
 
     Observable<Boolean> isGeth(String resourceId);
 
+    Observable<Boolean> isBesu(String resourceId);
+
     Observable<Boolean> deleteDatadirs(NetworkResources networkResources);
 
     Observable<Boolean> stopResource(String resourceId);

--- a/src/main/java/com/quorum/gauge/services/UnsupportedInfrastructureService.java
+++ b/src/main/java/com/quorum/gauge/services/UnsupportedInfrastructureService.java
@@ -79,6 +79,11 @@ public class UnsupportedInfrastructureService implements InfrastructureService, 
     }
 
     @Override
+    public Observable<Boolean> isBesu(String resourceId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Observable<Boolean> deleteDatadirs(NetworkResources networkResources) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/com/quorum/gauge/services/UtilService.java
+++ b/src/main/java/com/quorum/gauge/services/UtilService.java
@@ -21,6 +21,7 @@ package com.quorum.gauge.services;
 
 import com.quorum.gauge.common.QuorumNetworkProperty.Node;
 import com.quorum.gauge.common.QuorumNode;
+import com.quorum.gauge.ext.NodeInfo;
 import com.quorum.gauge.ext.PendingTransaction;
 import io.reactivex.Observable;
 import org.springframework.stereotype.Service;
@@ -67,6 +68,18 @@ public class UtilService extends AbstractService {
         );
 
         return request.flowable().toObservable().blockingFirst().getTransactions();
+    }
+
+    public String getNodeInfoName(final QuorumNode node) {
+        Request<?, NodeInfo> nodeInfoRequest = new Request<>(
+            "admin_nodeInfo",
+            null,
+            connectionFactory().getWeb3jService(node),
+            NodeInfo.class
+        );
+
+        NodeInfo nodeInfo = nodeInfoRequest.flowable().toObservable().blockingFirst();
+        return nodeInfo.getName();
     }
 
     public Observable<Boolean> getRpcModules(QuorumNode node) {

--- a/src/main/java/com/quorum/gauge/services/UtilService.java
+++ b/src/main/java/com/quorum/gauge/services/UtilService.java
@@ -70,18 +70,6 @@ public class UtilService extends AbstractService {
         return request.flowable().toObservable().blockingFirst().getTransactions();
     }
 
-    public String getNodeInfoName(final QuorumNode node) {
-        Request<?, NodeInfo> nodeInfoRequest = new Request<>(
-            "admin_nodeInfo",
-            null,
-            connectionFactory().getWeb3jService(node),
-            NodeInfo.class
-        );
-
-        NodeInfo nodeInfo = nodeInfoRequest.flowable().toObservable().blockingFirst();
-        return nodeInfo.getName();
-    }
-
     public Observable<Boolean> getRpcModules(QuorumNode node) {
         Request<?, GenericResponse> request = new Request<>(
             "rpc_modules",

--- a/src/specs/02_advanced/hybrid_validator_management_manage_besu.spec
+++ b/src/specs/02_advanced/hybrid_validator_management_manage_besu.spec
@@ -1,0 +1,55 @@
+# QBFT consensus - Validator and non-validator behaviour
+
+  Tags: networks/typical-hybrid::hybrid-template-q2b1, pre-condition/no-record-blocknumber, hybrid-validator-management-manage-besu
+
+This specification describes how validator and non-validator nodes behave in hybrid network
+ - validator node can seal new blocks
+ - non-validator node is not authorized to seal new blocks but can sync up
+
+* Start a Quorum Network, named it "mynetwork", consisting of "Node1,Node2,Node3"
+* Send some transactions to create blocks in network "mynetwork" and capture the latest block height as "latestBlockHeight"
+* Add "Node4" and join the network "mynetwork" as "nonvalidator"
+
+## A new node can sync up with the network but is not allowed to seal blocks
+
+  Tags: post-condition/datadir-cleanup, post-condition/network-cleanup, non-validator
+
+New node after being added to the network as non-validator node must not be able to seal new blocks
+
+* Deploy a simple smart contract from "Node4", verify it gets mined
+* Deploy a simple smart contract from "Node1", verify it gets mined
+* Record the current block number, named it as "blockHeightAfterContractsAreMinted"
+* Wait for node "Node4" to catch up to "blockHeightAfterContractsAreMinted"
+* Verify node "Node4" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
+* Besu node "Node4" is not a Validator
+
+## A new node is allowed to seal blocks after being proposed as a validator
+
+  Tags: post-condition/datadir-cleanup, post-condition/network-cleanup, propose-validator
+
+New node after being added to the network as non-valiator node, it's then proposed by other nodes to be validator node.
+Hence it is authorized to seal new blocks
+
+* Propose "Node4" to become validator by "Node1,Node2,Node3"
+* Deploy a simple smart contract from "Node4", verify it gets mined
+* Deploy a simple smart contract from "Node1", verify it gets mined
+* Record the current block number, named it as "blockHeightAfterContractsAreMinted"
+* Wait for node "Node4" to catch up to "blockHeightAfterContractsAreMinted"
+* Verify node "Node4" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
+* Besu node "Node4" is a Validator
+
+
+## A node can still sync up with the network but is not allowed to seal blocks after being proposed as a non-validator
+
+  Tags: post-condition/datadir-cleanup, post-condition/network-cleanup, propose-non-validator
+
+Nodes in a network can send proposal to remove a node from validator set
+
+* Propose "Node4" to become validator by "Node1,Node2,Node3"
+* Propose "Node1" to become non validator by "Node2,Node3,Node4"
+* Deploy a simple smart contract from "Node4", verify it gets mined
+* Deploy a simple smart contract from "Node1", verify it gets mined
+* Record the current block number, named it as "blockHeightAfterContractsAreMinted"
+* Wait for node "Node1" to catch up to "blockHeightAfterContractsAreMinted"
+* Verify node "Node1" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
+* "Node1" is not able to seal new blocks

--- a/src/specs/02_advanced/hybrid_validator_management_manage_besu.spec
+++ b/src/specs/02_advanced/hybrid_validator_management_manage_besu.spec
@@ -20,7 +20,6 @@ New node after being added to the network as non-validator node must not be able
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node4" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node4" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * Besu node "Node4" is not a Validator
 
 ## A new node is allowed to seal blocks after being proposed as a validator
@@ -35,7 +34,6 @@ Hence it is authorized to seal new blocks
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node4" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node4" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * Besu node "Node4" is a Validator
 
 
@@ -51,5 +49,4 @@ Nodes in a network can send proposal to remove a node from validator set
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node1" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node1" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * "Node1" is not able to seal new blocks

--- a/src/specs/02_advanced/hybrid_validator_management_manage_quorum.spec
+++ b/src/specs/02_advanced/hybrid_validator_management_manage_quorum.spec
@@ -20,7 +20,6 @@ New node after being added to the network as non-validator node must not be able
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node2" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node2" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * "Node2" is not able to seal new blocks
 
 ## A new node is allowed to seal blocks after being proposed as a validator
@@ -35,7 +34,6 @@ Hence it is authorized to seal new blocks
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node2" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node2" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * "Node2" is able to seal new blocks
 
 
@@ -51,5 +49,4 @@ Nodes in a network can send proposal to remove a node from validator set
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node1" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node1" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * "Node1" is not able to seal new blocks

--- a/src/specs/02_advanced/hybrid_validator_management_manage_quorum.spec
+++ b/src/specs/02_advanced/hybrid_validator_management_manage_quorum.spec
@@ -1,0 +1,55 @@
+# QBFT consensus - Validator and non-validator behaviour
+
+  Tags: networks/typical-hybrid::hybrid-template-q1b2, pre-condition/no-record-blocknumber, hybrid-validator-management-manage-quorum
+
+This specification describes how validator and non-validator nodes behave in hybrid network
+ - validator node can seal new blocks
+ - non-validator node is not authorized to seal new blocks but can sync up
+
+* Start a Quorum Network, named it "mynetwork", consisting of "Node1,Node3,Node4"
+* Send some transactions to create blocks in network "mynetwork" and capture the latest block height as "latestBlockHeight"
+* Add "Node2" and join the network "mynetwork" as "nonvalidator"
+
+## A new node can sync up with the network but is not allowed to seal blocks
+
+  Tags: post-condition/datadir-cleanup, post-condition/network-cleanup, non-validator
+
+New node after being added to the network as non-validator node must not be able to seal new blocks
+
+* Deploy a simple smart contract from "Node2", verify it gets mined
+* Deploy a simple smart contract from "Node1", verify it gets mined
+* Record the current block number, named it as "blockHeightAfterContractsAreMinted"
+* Wait for node "Node2" to catch up to "blockHeightAfterContractsAreMinted"
+* Verify node "Node2" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
+* "Node2" is not able to seal new blocks
+
+## A new node is allowed to seal blocks after being proposed as a validator
+
+  Tags: post-condition/datadir-cleanup, post-condition/network-cleanup, propose-validator
+
+New node after being added to the network as non-valiator node, it's then proposed by other nodes to be validator node.
+Hence it is authorized to seal new blocks
+
+* Propose "Node2" to become validator by "Node1,Node3,Node4"
+* Deploy a simple smart contract from "Node2", verify it gets mined
+* Deploy a simple smart contract from "Node1", verify it gets mined
+* Record the current block number, named it as "blockHeightAfterContractsAreMinted"
+* Wait for node "Node2" to catch up to "blockHeightAfterContractsAreMinted"
+* Verify node "Node2" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
+* "Node2" is able to seal new blocks
+
+
+## A node can still sync up with the network but is not allowed to seal blocks after being proposed as a non-validator
+
+  Tags: post-condition/datadir-cleanup, post-condition/network-cleanup, propose-non-validator
+
+Nodes in a network can send proposal to remove a node from validator set
+
+* Propose "Node2" to become validator by "Node1,Node3,Node4"
+* Propose "Node1" to become non validator by "Node2,Node3,Node4"
+* Deploy a simple smart contract from "Node2", verify it gets mined
+* Deploy a simple smart contract from "Node1", verify it gets mined
+* Record the current block number, named it as "blockHeightAfterContractsAreMinted"
+* Wait for node "Node1" to catch up to "blockHeightAfterContractsAreMinted"
+* Verify node "Node1" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
+* "Node1" is not able to seal new blocks

--- a/src/specs/02_advanced/istanbul_block_synchronization.spec
+++ b/src/specs/02_advanced/istanbul_block_synchronization.spec
@@ -1,6 +1,6 @@
 # Block synchronization with gcmode when using Istanbul BFT consensus
 
-  Tags: networks/template::istanbul-3plus1, pre-condition/no-record-blocknumber, gcmode, block-sync
+  Tags: networks/template::istanbul-3plus1, networks/template::qbft-3plus1, pre-condition/no-record-blocknumber, gcmode, block-sync
 
   Geth 1.8.12 introduces `--gcmode=full/archive`. This controls trie pruning which is enabled by default on all `--syncmode`.
   Setting `--gcmode=archive` would retain all historical data.

--- a/src/specs/02_advanced/istanbul_validator_management.spec
+++ b/src/specs/02_advanced/istanbul_validator_management.spec
@@ -20,7 +20,6 @@ New node after being added to the network as non-validator node must not be able
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node4" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node4" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * "Node4" is not able to seal new blocks
 
 ## A new node is allowed to seal blocks after being proposed as a validator
@@ -35,7 +34,6 @@ Hence it is authorized to seal new blocks
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node4" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node4" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * "Node4" is able to seal new blocks
 
 
@@ -51,5 +49,4 @@ Nodes in a network can send proposal to remove a node from validator set
 * Deploy a simple smart contract from "Node1", verify it gets mined
 * Record the current block number, named it as "blockHeightAfterContractsAreMinted"
 * Wait for node "Node1" to catch up to "blockHeightAfterContractsAreMinted"
-* Verify node "Node1" has the block height greater or equal to "blockHeightAfterContractsAreMinted"
 * "Node1" is not able to seal new blocks


### PR DESCRIPTION
* Add validator management test for hybrid network. 
  * `hybrid_validator_management_manage_besu.spec` tests validator management by adding/removing besu node and checks if the network performs fine
  * `hybrid_validator_management_manage_quorum.spec` tests validator management by adding/removing quorum node and checks if the network performs fine
* Templating support has been added to the `typical-hybrid` module using `terraform.hybrid-template-q1b2.tfvars` and `terraform.hybrid-template-q2b1.tfvars` 