### PR TITLE
Tests for mandatory recipients

### DIFF
--- a/.github/workflows/run-extra.yml
+++ b/.github/workflows/run-extra.yml
@@ -97,11 +97,11 @@ jobs:
         # list of tag expression being executed in parallel
         include:
           # privacy enhancements tests
-          - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || basic-raft || (advanced && raft) || networks/typical::raft'
+          - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || mandatory-recipients || basic-raft || (advanced && raft) || networks/typical::raft'
             privacy-enhancements: true
             privacy-precompile: false
             privacy-marker-transactions: false
-          - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
+          - tag: '(basic && !privacy-enhancements-disabled) || privacy-enhancements || mandatory-recipients || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
             privacy-enhancements: true
             privacy-precompile: false
             privacy-marker-transactions: false
@@ -147,15 +147,15 @@ jobs:
             privacy-precompile: true
             privacy-marker-transactions: true
           # privacy enhancements + privacy precompile/privacy marker transaction tests
-          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || privacy-precompile-enabled || basic-raft || (advanced && raft) || networks/typical::raft'
+          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || mandatory-recipients || privacy-precompile-enabled || basic-raft || (advanced && raft) || networks/typical::raft'
             privacy-enhancements: true
             privacy-precompile: true
             privacy-marker-transactions: true
-          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || privacy-precompile-enabled || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
+          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || mandatory-recipients || privacy-precompile-enabled || basic-istanbul || (advanced && istanbul) || networks/typical::istanbul'
             privacy-enhancements: true
             privacy-precompile: true
             privacy-marker-transactions: true
-          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || privacy-precompile-enabled || basic-istanbul || (advanced && istanbul) || networks/typical::qbft'
+          - tag: '(basic && !privacy-enhancements-disabled && !privacy-precompile-disabled) || privacy-enhancements || mandatory-recipients || privacy-precompile-enabled || basic-istanbul || (advanced && istanbul) || networks/typical::qbft'
             privacy-enhancements: true
             privacy-precompile: true
             privacy-marker-transactions: true

--- a/src/main/java/com/quorum/gauge/common/PrivacyFlag.java
+++ b/src/main/java/com/quorum/gauge/common/PrivacyFlag.java
@@ -20,7 +20,7 @@
 package com.quorum.gauge.common;
 
 public enum PrivacyFlag {
-    StandardPrivate(0), PartyProtection(1), StateValidation(3);
+    StandardPrivate(0), PartyProtection(1), MandatoryRecipients(2), StateValidation(3);
 
     private int i;
 

--- a/src/main/java/com/quorum/gauge/services/NestedContractService.java
+++ b/src/main/java/com/quorum/gauge/services/NestedContractService.java
@@ -74,6 +74,24 @@ public class NestedContractService extends AbstractService {
         });
     }
 
+    public Observable<? extends Contract> createC1ContractWithMandatoryRecipients(int initialValue, QuorumNode source, List<QuorumNode> target, List<QuorumNode> mandatoryFor, List<PrivacyFlag> flags) {
+        Quorum client = connectionFactory().getConnection(source);
+        return accountService.getDefaultAccountAddress(source).flatMap(address -> {
+            ClientTransactionManager clientTransactionManager = new EnhancedClientTransactionManager(
+                client,
+                address,
+                null,
+                target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
+                mandatoryFor.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
+                flags);
+            return C1.deploy(client,
+                clientTransactionManager,
+                BigInteger.valueOf(0),
+                DEFAULT_GAS_LIMIT,
+                BigInteger.valueOf(initialValue)).flowable().toObservable();
+        });
+    }
+
     public Observable<? extends Contract> createPublicC1Contract(int initialValue, QuorumNode source) {
         Quorum client = connectionFactory().getConnection(source);
         return accountService.getDefaultAccountAddress(source).flatMap(address -> {
@@ -102,6 +120,24 @@ public class NestedContractService extends AbstractService {
                 address,
                 null,
                 target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
+                flags);
+            return C2.deploy(client,
+                clientTransactionManager,
+                BigInteger.valueOf(0),
+                DEFAULT_GAS_LIMIT,
+                c1Address).flowable().toObservable();
+        });
+    }
+
+    public Observable<? extends Contract> createC2ContractWithMandatoryRecipients(String c1Address, QuorumNode source, List<QuorumNode> target, List<QuorumNode> mandatoryFor, List<PrivacyFlag> flags) {
+        Quorum client = connectionFactory().getConnection(source);
+        return accountService.getDefaultAccountAddress(source).flatMap(address -> {
+            ClientTransactionManager clientTransactionManager = new EnhancedClientTransactionManager(
+                client,
+                address,
+                null,
+                target.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
+                mandatoryFor.stream().map(n -> privacyService.id(n)).collect(Collectors.toList()),
                 flags);
             return C2.deploy(client,
                 clientTransactionManager,

--- a/src/specs/01_basic/mandatory_recipients.spec
+++ b/src/specs/01_basic/mandatory_recipients.spec
@@ -1,6 +1,6 @@
 # Validate a subset of recipients that are mandatory for a specific private contract
 
- Tags: privacy, non-party, privacy-enhancements, mandatory-recipients, extension
+ Tags: mandatory-recipients
 
 Private smart contract can have a subset of participants that are mandated to be included in all transactions
 for a particular contract

--- a/src/specs/01_basic/mandatory_recipients.spec
+++ b/src/specs/01_basic/mandatory_recipients.spec
@@ -1,0 +1,61 @@
+# Validate a subset of recipients that are mandatory for a specific private contract
+
+ Tags: privacy, non-party, privacy-enhancements, mandatory-recipients, extension
+
+Private smart contract can have a subset of participants that are mandated to be included in all transactions
+for a particular contract
+
+## Transactions sent with invalid mandatory recipients data will be rejected
+
+* Deploy a "StandardPrivate" contract `SimpleStorage` with initial value "42" in "Node1"'s default account and it's private for "Node2,Node3" and mandatory for "Node3" fails with message "privacy metadata invalid. mandatory recipients are only applicable for PrivacyFlag=2(MandatoryRecipients)"
+* Deploy a "PartyProtection" contract `SimpleStorage` with initial value "42" in "Node1"'s default account and it's private for "Node2,Node3" and mandatory for "Node3" fails with message "privacy metadata invalid. mandatory recipients are only applicable for PrivacyFlag=2(MandatoryRecipients)"
+* Deploy a "StateValidation" contract `SimpleStorage` with initial value "42" in "Node1"'s default account and it's private for "Node2,Node3" and mandatory for "Node3" fails with message "privacy metadata invalid. mandatory recipients are only applicable for PrivacyFlag=2(MandatoryRecipients)"
+* Deploy a MandatoryRecipients contract `SimpleStorage` with no mandatory recipients data fails with message "missing mandatory recipients data. if no mandatory recipients required consider using PrivacyFlag=1(PartyProtection)"
+
+## Transactions sent with mandatory recipients not included in participant list will be rejected
+
+* Deploy a "MandatoryRecipients" contract `SimpleStorage` with initial value "42" in "Node1"'s default account and it's private for "Node2,Node3" and mandatory for "Node4" fails with message "mandatory recipients not included in the participant list"
+* Deploy a "MandatoryRecipients" contract `SimpleStorage` with initial value "42" in "Node1"'s default account and it's private for "Node2,Node3" and mandatory for "Node3,Node4" fails with message "mandatory recipients not included in the participant list"
+
+## The mandatory recipients will have the full view of the private state of the contract
+
+* Deploy a "MandatoryRecipients" contract `SimpleStorage` with initial value "30" in "Node1"'s default account and it's private for "Node2" and mandatory for "Node2", named this contract as "contract12_2"
+* Fail to execute "MandatoryRecipients" simple contract("contract12_2")'s `set()` function with new arbitrary value in "Node1" and it's private for "Node1" and mandatory for "Node1" with error "Privacy metadata mismatched"
+* Fire and forget execution of "MandatoryRecipients" simple contract("contract12_2")'s `set()` function with new value "19" in "Node1" and it's private for "Node2" and mandatory for "Node2"
+* Fire and forget execution of "MandatoryRecipients" simple contract("contract12_2")'s `set()` function with new value "10" in "Node2" and it's private for "Node2" and mandatory for "Node2"
+* Execute "contract12_2"'s `get()` function in "Node1" returns "19"
+* Execute "contract12_2"'s `get()` function in "Node2" returns "10"
+* Deploy a "MandatoryRecipients" contract `SimpleStorage` with initial value "30" in "Node2"'s default account and it's private for "Node3,Node4" and mandatory for "Node2", named this contract as "contract234_2"
+* Fail to execute "MandatoryRecipients" simple contract("contract234_2")'s `set()` function with new arbitrary value in "Node3" and it's private for "Node4" and no mandatory recipients with error "Error processing transaction request"
+* Fail to execute "MandatoryRecipients" simple contract("contract234_2")'s `set()` function with new arbitrary value in "Node4" and it's private for "Node3" and no mandatory recipients with error "Error processing transaction request"
+* Fail to execute "MandatoryRecipients" simple contract("contract234_2")'s `set()` function with new arbitrary value in "Node3" and it's private for "Node4" and mandatory for "Node3" with error "Privacy metadata mismatched"
+* Fail to execute "MandatoryRecipients" simple contract("contract234_2")'s `set()` function with new arbitrary value in "Node4" and it's private for "Node3" and mandatory for "Node4" with error "Privacy metadata mismatched"
+* Fire and forget execution of "MandatoryRecipients" simple contract("contract234_2")'s `set()` function with new value "10" in "Node2" and it's private for "Node2" and mandatory for "Node2"
+* Execute "contract234_2"'s `get()` function in "Node2" returns "10"
+* Execute "contract234_2"'s `get()` function in "Node3" returns "30"
+* Execute "contract234_2"'s `get()` function in "Node4" returns "30"
+
+## Mandatory recipients are validated in nested contracts
+
+* Deploy a MR contract `C1` with initial value "42" in "Node1"'s default account and it's private for "Node2", mandatory for "Node2" named this contract as "contract12_2"
+* "contract12_2" is deployed "successfully" in "Node1,Node2"
+* Deploy a MR contract `C2` with initial value "contract12_2" in "Node2"'s default account and it's private for "Node3" mandatory for "Node3", named this contract as "contract23_3"
+* "contract23_3" is deployed "successfully" in "Node2,Node3"
+The next step should fail as part of Party Protection check - Node3 was not a participant of contract C1 - which the transaction was going to affect
+* Fail to execute "MandatoryRecipients" simple contract("contract23_3")'s `set()` function with new arbitrary value in "Node3" and it's private for "Node2" and mandatory for "Node3" with error "Error processing transaction request"
+This step should fail the mandatory validations
+* Fail to execute "MandatoryRecipients" simple contract("contract23_3")'s `set()` function with new arbitrary value in "Node2" and it's private for "Node3" and mandatory for "Node3" with error "Privacy metadata mismatched"
+* Fire and forget execution of "MandatoryRecipients" simple contract("contract23_3")'s `set()` function with new value "10" in "Node2" and it's private for "Node3" and mandatory for "Node2,Node3"
+* Execute "contract23_3"'s `get()` function in "Node2" returns "10"
+* Execute "contract12_2"'s `get()` function in "Node1" returns "42"
+
+## Contract with mandatory recipients can be extended
+Failure to execute transaction with invalid mandatory recipients on the extended node proves that it has the relevant
+mandatory recipients data to perform validations.
+* Deploy a "MandatoryRecipients" contract `SimpleStorage` with initial value "30" in "Node1"'s default account and it's private for "Node2" and mandatory for "Node1", named this contract as "contract12_1_3"
+* Initiate "contract12_1_3" extension from "Node1" to "Node3". Contract extension accepted in receiving node. Check that state value in receiving node is "30"
+* Fail to execute "MandatoryRecipients" simple contract("contract12_1_3")'s `set()` function with new arbitrary value in "Node3" and it's private for "Node2" and mandatory for "Node3" with error "Privacy metadata mismatched"
+* Fire and forget execution of "MandatoryRecipients" simple contract("contract12_1_3")'s `set()` function with new value "10" in "Node3" and it's private for "Node1" and mandatory for "Node1"
+* Execute "contract12_1_3"'s `get()` function in "Node1" returns "10"
+* Execute "contract12_1_3"'s `get()` function in "Node3" returns "10"
+* Execute "contract12_1_3"'s `get()` function in "Node2" returns "30"

--- a/src/test/java/com/quorum/gauge/MandatoryRecipients.java
+++ b/src/test/java/com/quorum/gauge/MandatoryRecipients.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.quorum.gauge;
+
+import com.quorum.gauge.common.PrivacyFlag;
+import com.quorum.gauge.common.QuorumNode;
+import com.quorum.gauge.common.RetryWithDelay;
+import com.quorum.gauge.core.AbstractSpecImplementation;
+import com.quorum.gauge.services.AbstractService;
+import com.thoughtworks.gauge.Step;
+import com.thoughtworks.gauge.datastore.DataStoreFactory;
+import org.springframework.stereotype.Service;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.tx.Contract;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+@Service
+public class MandatoryRecipients extends AbstractSpecImplementation {
+
+    @Step("Deploy a <flag> contract `SimpleStorage` with initial value <initialValue> in <source>'s default account and it's private for <privateFor> and mandatory for <mandatoryFor>, named this contract as <contractName>")
+    public void deploySimpleContract(PrivacyFlag flag, int initialValue, QuorumNode source, String privateFor, String mandatoryFor, String contractName) {
+        Contract contract = contractService.createSimpleContract(
+            initialValue,
+            source,
+            null, Arrays.stream(privateFor.split(","))
+                .map(s -> QuorumNode.valueOf(s))
+                .collect(Collectors.toList()),
+            AbstractService.DEFAULT_GAS_LIMIT,
+            Arrays.asList(flag),
+            Arrays.stream(mandatoryFor.split(","))
+                .map(QuorumNode::valueOf)
+                .collect(Collectors.toList())
+        ).blockingFirst();
+
+        DataStoreFactory.getSpecDataStore().put(contractName, contract);
+        DataStoreFactory.getScenarioDataStore().put(contractName, contract);
+    }
+
+    @Step("Deploy a <flag> contract `SimpleStorage` with initial value <initialValue> in <source>'s default account and it's private for <privateFor> and mandatory for <mandatoryFor> fails with message <failureMessage>")
+    public void deploySimpleContractFails(PrivacyFlag flag, int initialValue, QuorumNode source, String privateFor, String mandatoryFor, String failureMessage) {
+        assertThatThrownBy(() -> contractService.createSimpleContract(
+            initialValue,
+            source,
+            null, Arrays.stream(privateFor.split(","))
+                .map(s -> QuorumNode.valueOf(s))
+                .collect(Collectors.toList()),
+            AbstractService.DEFAULT_GAS_LIMIT,
+            Arrays.asList(flag),
+            Arrays.stream(mandatoryFor.split(","))
+                .map(QuorumNode::valueOf)
+                .collect(Collectors.toList())
+        ).blockingFirst())
+        .as("Expected exception thrown")
+            .hasMessageContaining(failureMessage);
+    }
+
+    @Step("Deploy a MandatoryRecipients contract `SimpleStorage` with no mandatory recipients data fails with message <failureMessage>")
+    public void deploySimpleContractMissingDataFails(String failureMessage) {
+        assertThatThrownBy(() -> contractService.createSimpleContract(
+            42,
+            QuorumNode.Node1,
+            null,
+            Arrays.stream("Node2".split(","))
+                .map(s -> QuorumNode.valueOf(s))
+                .collect(Collectors.toList()),
+            AbstractService.DEFAULT_GAS_LIMIT,
+            Arrays.asList(PrivacyFlag.MandatoryRecipients)
+        ).blockingFirst())
+            .as("Expected exception thrown")
+            .hasMessageContaining(failureMessage);
+    }
+
+    @Step("Fail to execute <flag> simple contract(<contractName>)'s `set()` function with new arbitrary value in <node> and it's private for <privateFor> and mandatory for <mandatoryFor> with error <error>")
+    public void updateSimpleContractFails(PrivacyFlag flag, String contractName, QuorumNode node, String privateFor, String mandatoryFor, String error) {
+        Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
+        int arbitraryValue = new Random().nextInt(100) + 1000;
+
+        assertThatThrownBy(
+            () -> contractService.updateSimpleContractWithMandatoryRecipients(
+                node,
+                Arrays.stream(privateFor.split(",")).map(s -> QuorumNode.valueOf(s)).collect(Collectors.toList()),
+                c.getContractAddress(),
+                arbitraryValue,
+                Arrays.asList(flag),
+                Arrays.stream(mandatoryFor.split(",")).map(s -> QuorumNode.valueOf(s)).collect(Collectors.toList()))
+                .blockingFirst()
+        ).as("Expected exception thrown")
+            .hasMessageContaining(error);
+    }
+
+    @Step("Fail to execute <flag> simple contract(<contractName>)'s `set()` function with new arbitrary value in <node> and it's private for <privateFor> and no mandatory recipients with error <error>")
+    public void updateSimpleContractMissingDataFails(PrivacyFlag flag, String contractName, QuorumNode node, String privateFor, String error) {
+        Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
+        int arbitraryValue = new Random().nextInt(100) + 1000;
+
+        assertThatThrownBy(
+            () -> contractService.updateSimpleContract(
+                node,
+                Arrays.stream(privateFor.split(",")).map(s -> QuorumNode.valueOf(s)).collect(Collectors.toList()),
+                c.getContractAddress(),
+                arbitraryValue,
+                Arrays.asList(flag))
+                .blockingFirst()
+        ).as("Expected exception thrown")
+            .hasMessageContaining(error);
+    }
+
+    @Step("Fire and forget execution of <flag> simple contract(<contractName>)'s `set()` function with new value <value> in <node> and it's private for <privateFor> and mandatory for <mandatoryFor>")
+    public void updateSimpleContract(PrivacyFlag flag, String contractName, String value, QuorumNode node, String privateFor, String mandatoryFor) {
+        Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
+        int intValue = Integer.parseInt(value);
+
+        TransactionReceipt receipt = contractService.updateSimpleContractWithMandatoryRecipients(
+            node,
+            Arrays.stream(privateFor.split(",")).map(s -> QuorumNode.valueOf(s)).collect(Collectors.toList()),
+            c.getContractAddress(),
+            intValue,
+            Arrays.asList(flag),
+            Arrays.stream(mandatoryFor.split(",")).map(s -> QuorumNode.valueOf(s)).collect(Collectors.toList()))
+            .blockingFirst();
+        if (receipt != null) {
+            String txHashKey = contractName + "_transactionHash";
+            DataStoreFactory.getSpecDataStore().put(txHashKey, receipt.getTransactionHash());
+            DataStoreFactory.getScenarioDataStore().put(txHashKey, receipt.getTransactionHash());
+        }
+    }
+
+    @Step("Execute <contractName>'s `get()` function in <node> returns <expectedValue>")
+    public void getValueSimpleContract(String contractName, QuorumNode node, int expectedValue) {
+        Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
+        // check transaction receipt to make sure the state is ready
+        assertThat(c.getTransactionReceipt().isPresent()).isTrue();
+        transactionService.getTransactionReceipt(node, c.getTransactionReceipt().get().getTransactionHash())
+            .map(ethGetTransactionReceipt -> {
+                if (ethGetTransactionReceipt.getTransactionReceipt().isPresent()) {
+                    return ethGetTransactionReceipt;
+                } else {
+                    throw new RuntimeException("retry");
+                }
+            }).retryWhen(new RetryWithDelay(5, 1000))
+            .blockingSubscribe();
+        int actualValue = contractService.readSimpleContractValue(node, c.getContractAddress());
+
+        assertThat(actualValue).isEqualTo(expectedValue);
+    }
+
+    @Step("Deploy a MR contract `C1` with initial value <initialValue> in <source>'s default account and it's private for <privateFor>, mandatory for <mandatoryFor> named this contract as <contractName>")
+    public void deployC1Contract(int initialValue, QuorumNode source, String privateFor, String mandatoryFor, String contractName) {
+        Contract contract = nestedContractService.createC1ContractWithMandatoryRecipients(
+            initialValue,
+            source,
+            Arrays.stream(privateFor.split(","))
+                .map(s -> QuorumNode.valueOf(s))
+                .collect(Collectors.toList()),
+            Arrays.stream(mandatoryFor.split(","))
+                .map(s -> QuorumNode.valueOf(s))
+                .collect(Collectors.toList()),
+            Arrays.asList(PrivacyFlag.MandatoryRecipients)
+        ).blockingFirst();
+
+        DataStoreFactory.getSpecDataStore().put(contractName, contract);
+        DataStoreFactory.getScenarioDataStore().put(contractName, contract);
+    }
+
+    @Step("Deploy a MR contract `C2` with initial value <c1ContractName> in <source>'s default account and it's private for <privateFor> mandatory for <mandatoryFor>, named this contract as <contractName>")
+    public void deployC2Contract(String c1ContractName, QuorumNode source, String privateFor, String mandatoryFor, String contractName) {
+        Contract c1 = mustHaveValue(c1ContractName, Contract.class);
+        Contract contract = nestedContractService.createC2ContractWithMandatoryRecipients(
+            c1.getContractAddress(),
+            source,
+            Arrays.stream(privateFor.split(","))
+                .map(s -> QuorumNode.valueOf(s))
+                .collect(Collectors.toList()),
+            Arrays.stream(mandatoryFor.split(","))
+                .map(s -> QuorumNode.valueOf(s))
+                .collect(Collectors.toList()),
+            Arrays.asList(PrivacyFlag.MandatoryRecipients)
+        ).blockingFirst();
+
+        DataStoreFactory.getSpecDataStore().put(contractName, contract);
+        DataStoreFactory.getScenarioDataStore().put(contractName, contract);
+    }
+
+
+}


### PR DESCRIPTION
- Add `MandatoryRecipients(2)` privacy flag
- Update `EnhancedClientTransactionManager` to send transactions with mandatory recipients
- Test specs for mandatory recipients 