### PR TITLE
modify wait condition for container, require healthy status

### DIFF
--- a/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
+++ b/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
@@ -325,10 +325,11 @@ public class DockerInfrastructureService
     }
 
     /**
-     * It's possible that container is still starting up even true is returned
+     * Wait for container to be in "healthy" status, timeout is 3 * 30 seconds
+     * 
      *
      * @param resourceId containder Id
-     * @return true if container is not dead
+     * @return true if container is in "healthy" status
      */
     @Override
     public Observable<Boolean> wait(String resourceId) {
@@ -345,7 +346,7 @@ public class DockerInfrastructureService
                            Thread.sleep(3000);
                        }
                    }
-                   return true;
+                   return false;
                });
     }
 

--- a/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
+++ b/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
@@ -325,7 +325,8 @@ public class DockerInfrastructureService
     }
 
     /**
-     * Wait for container to be in "healthy" status, timeout is 3 * 30 seconds
+     * Wait for container to be in "healthy" status
+     * Timeout is 3 * 30 seconds
      * 
      *
      * @param resourceId containder Id


### PR DESCRIPTION
### Summary

Require `healthy` status only for wait condition of docker container. If max number of retry is reached, return non ready.