### PR TITLE
For some reason openjdk-14 is not available in alpine:latest (3.14)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:edge
 
 ARG TERRAFORM_VERSION=0.14.7
 ARG GAUGE_VERSION=1.3.3


### PR DESCRIPTION
- switching to alpine:edge for now
- this could be switch back at a later date