### PR TITLE
Fix Ethsigner to run with non-root user

### DIFF
--- a/networks/_modules/docker-besu/ethsigner.tf
+++ b/networks/_modules/docker-besu/ethsigner.tf
@@ -51,9 +51,6 @@ resource "docker_container" "ethsigner" {
     <<RUN
 echo "EthSigner${count.index + 1}"
 
-apt-get update
-apt-get install -y netcat
-
 /opt/ethsigner/bin/ethsigner \
   --chain-id=${var.chainId} \
   --http-listen-host=0.0.0.0 \

--- a/networks/_modules/docker-helper/variables.tf
+++ b/networks/_modules/docker-helper/variables.tf
@@ -87,7 +87,7 @@ variable "ethsigner" {
   })
   default = {
     container = {
-      image = { name = "consensys/ethsigner:latest", local = false }
+      image = { name = "consensys/ethsigner:develop", local = false }
       port  = 8545
     }
     host = {

--- a/networks/_modules/ignite-besu/bootstrap.tf
+++ b/networks/_modules/ignite-besu/bootstrap.tf
@@ -49,6 +49,14 @@ resource "quorum_bootstrap_keystore" "accountkeys-generator" {
   }
 }
 
+resource "null_resource" "accountkeys-permission" {
+  count    = local.number_of_nodes
+  provisioner "local-exec" {
+    command = "chmod 644 ${format("%s/%s", local.ethsigner_dirs[count.index], local.keystore_folder)}/*"
+  }
+  depends_on = [    quorum_bootstrap_keystore.accountkeys-generator,  ]
+}
+
 resource "local_file" "keystore_password" {
   count    = local.number_of_nodes
   filename = format("%s/%s", local.ethsigner_dirs[count.index], local.keystore_password_file)

--- a/networks/_modules/ignite-besu/bootstrap.tf
+++ b/networks/_modules/ignite-besu/bootstrap.tf
@@ -47,14 +47,10 @@ resource "quorum_bootstrap_keystore" "accountkeys-generator" {
       balance    = "1000000000000000000000000000"
     }
   }
-}
 
-resource "null_resource" "accountkeys-permission" {
-  count    = local.number_of_nodes
   provisioner "local-exec" {
     command = "chmod 644 ${format("%s/%s", local.ethsigner_dirs[count.index], local.keystore_folder)}/*"
   }
-  depends_on = [    quorum_bootstrap_keystore.accountkeys-generator,  ]
 }
 
 resource "local_file" "keystore_password" {

--- a/networks/typical-besu/variables.tf
+++ b/networks/typical-besu/variables.tf
@@ -45,7 +45,7 @@ variable "tessera_docker_image" {
 
 variable "ethsigner_docker_image" {
   type        = object({ name = string, local = bool })
-  default     = { name = "consensys/ethsigner:latest", local = false }
+  default     = { name = "consensys/ethsigner:develop", local = false }
   description = "Local=true indicates that the image is already available locally and don't need to pull from registry"
 }
 

--- a/networks/typical-hybrid/bootstrap.tf
+++ b/networks/typical-hybrid/bootstrap.tf
@@ -69,6 +69,14 @@ resource "quorum_bootstrap_keystore" "besu-accountkeys-generator" {
   }
 }
 
+resource "null_resource" "besu-accountkeys-permission" {
+  count    = local.number_of_besu_nodes
+  provisioner "local-exec" {
+    command = "chmod 644 ${format("%s/%s", local.ethsigner_dirs[count.index], local.keystore_folder)}/*"
+  }
+  depends_on = [    quorum_bootstrap_keystore.besu-accountkeys-generator,  ]
+}
+
 resource "quorum_bootstrap_keystore" "quorum-accountkeys-generator" {
   count                = local.number_of_quorum_nodes
   keystore_dir         = format("%s/%s%s/keystore", quorum_bootstrap_network.this.network_dir_abs, local.quorum_node_dir_prefix, count.index)

--- a/networks/typical-hybrid/bootstrap.tf
+++ b/networks/typical-hybrid/bootstrap.tf
@@ -67,14 +67,9 @@ resource "quorum_bootstrap_keystore" "besu-accountkeys-generator" {
       balance    = "1000000000000000000000000000"
     }
   }
-}
-
-resource "null_resource" "besu-accountkeys-permission" {
-  count    = local.number_of_besu_nodes
   provisioner "local-exec" {
     command = "chmod 644 ${format("%s/%s", local.ethsigner_dirs[count.index], local.keystore_folder)}/*"
   }
-  depends_on = [    quorum_bootstrap_keystore.besu-accountkeys-generator,  ]
 }
 
 resource "quorum_bootstrap_keystore" "quorum-accountkeys-generator" {

--- a/networks/typical-hybrid/variables.tf
+++ b/networks/typical-hybrid/variables.tf
@@ -141,7 +141,7 @@ variable "ethsigner" {
   })
   default = {
     container = {
-      image = { name = "consensys/ethsigner:latest", local = false }
+      image = { name = "consensys/ethsigner:develop", local = false }
       port  = 8545
     }
     host = {


### PR DESCRIPTION
## Note: Should be merge after this EthSigner PR is merged: https://github.com/ConsenSys/ethsigner/pull/428

-- Change v3 keystore file to world readable so that ethsigner container can
read it
-- Revert ethsigner container to use develop
-- Remove netcat manual installation in ethsigner docker definition as
it required root user. It will be available via original image instead.