### PR TITLE
revert version of tessera to see if that fixes error

### DIFF
--- a/networks/typical-besu/variables.tf
+++ b/networks/typical-besu/variables.tf
@@ -39,7 +39,7 @@ variable "besu_docker_image" {
 
 variable "tessera_docker_image" {
   type        = object({ name = string, local = bool })
-  default     = { name = "quorumengineering/tessera:develop", local = false }
+  default     = { name = "quorumengineering/tessera:22.1.5", local = false }
   description = "Local=true indicates that the image is already available locally and don't need to pull from registry"
 }
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Seeing this error in besu CI 
```
2022-08-19 19:14:41.104  INFO 481 --- [           main] com.quorum.gauge.DockerWaitMain          : /run-at-besu-node0(b3f94df194a5): status = running, health = starting, dead = false, ongoing = true
2022-08-19 19:14:41.124  INFO 481 --- [           main] com.quorum.gauge.DockerWaitMain          : /run-at-besu-tm0(daec3e08fbe1): status = exited, health = unhealthy, dead = true, ongoing = true
2022-08-19 19:14:41.125  INFO 481 --- [           main] com.quorum.gauge.DockerWaitMain          : /run-at-besu-tm0(daec3e08fbe1) IS DEAD: status = exited, health = unhealthy, dead = true, ongoing = true
STDOUT: Tessera Besu 1
STDERR: /bin/sh: 6: //: Permission denied
STDERR: /bin/sh: 9: [[: not found
STDERR: /bin/sh: 13: //: Permission denied
STDERR: /bin/sh: 28: [: unexpected operator
STDOUT: /tessera/bin/tessera --override jdbc.url=jdbc:h2:/data/tm/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0 --override serverConfigs[1].serverAddress=http://172.16.142.101:9081 --override serverConfigs[2].sslConfig.serverKeyStore=/data/tm/serverKeyStore --override serverConfigs[2].sslConfig.serverTrustStore=/data/tm/serverTrustStore --override serverConfigs[2].sslConfig.knownClientsFile=/data/tm/knownClientsFile --override serverConfigs[2].sslConfig.clientKeyStore=/data/tm/clientKeyStore --override serverConfigs[2].sslConfig.clientTrustStore=/data/tm/clientTrustStore --override serverConfigs[2].sslConfig.knownServersFile=/data/tm/knownServersFile --configfile /data/tm/config.json
STDOUT: Copying mounted datadir to /data/tm
```